### PR TITLE
feat: allow customize validation errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,9 @@ module.exports = {
     'promise/no-callback-in-promise': ['error', { exceptions: ['next'] }],
     'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
     'prefer-template': 'error',
-    'prefer-arrow-callback': 'warn'
+    'prefer-arrow-callback': 'warn',
+    'linebreak-style': ['error', 'unix'],
+    'no-console': 'error'
   },
   overrides: [
     {

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Available options are:
 | `bucket`              |     `string`     | `"node-uploadx"` | _S3 or GCS bucket_                                  |
 | `path`                |     `string`     |    `"/files"`    | _Node http base path_                               |
 | `allowMIME`           |    `string[]`    |    `["*\*"]`     | _Array of allowed MIME types_                       |
-| `maxUploadSize`       | `string\|number` |     `"50GB"`     | _Limit allowed file size_                           |
+| `maxUploadSize`       | `string\|number` |     `"5TB"`      | _Limit allowed file size_                           |
 | `useRelativeLocation` |    `boolean`     |     `false`      | _Generate relative upload link_                     |
 | `filename`            |    `Function`    |                  | _Filename generator function_                       |
 | `onComplete`          |    `Function`    |                  | _File upload complete callback_                     |

--- a/examples/express-basic.ts
+++ b/examples/express-basic.ts
@@ -1,9 +1,11 @@
+import { DiskStorageOptions, multipart, uploadx } from '@uploadx/core';
 import * as express from 'express';
-import { multipart, uploadx, DiskStorageOptions } from '@uploadx/core';
 
 const app = express();
 
 const opts: DiskStorageOptions = {
+  maxUploadSize: '1GB',
+  allowMIME: ['video/*', 'image/*'],
   onComplete: file => {
     console.log('File upload complete: ', file);
     return file.status;

--- a/examples/express-gcs.ts
+++ b/examples/express-gcs.ts
@@ -3,7 +3,7 @@ import { GCStorage, uploadx } from 'node-uploadx';
 
 const app = express();
 
-const storage = new GCStorage();
+const storage = new GCStorage({ maxUploadSize: '1GB' });
 
 storage.onComplete = ({ uri, id }) => {
   console.log(`File upload complete, storage path: ${uri}`);

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -1,6 +1,6 @@
 import * as express from 'express';
 import { promises } from 'fs';
-import { DiskFile, DiskStorage, multipart, OnComplete, uploadx } from 'node-uploadx';
+import { DiskFile, DiskStorage, OnComplete, uploadx } from 'node-uploadx';
 
 const app = express();
 
@@ -25,15 +25,14 @@ const onComplete: OnComplete<DiskFile> = async file => {
   };
 };
 
-const options = new DiskStorage({
-  allowMIME: ['video/*', 'image/*'],
+const storage = new DiskStorage({
+  allowMIME: { value: ['video/*'], message: 'Only Video files is supported.', statusCode: 415 },
+  maxUploadSize: { value: '1GB', message: 'File is too big.', statusCode: 413 },
   directory: 'upload',
   onComplete
 });
 
-app.use('/files', express.static('files'));
-app.use('/upload/files', uploadx(options));
-app.use('/files', multipart(options));
+app.use('/files', express.static('files'), uploadx({ storage }));
 
 app.listen(3003, () => {
   console.log('listening on port:', 3003);

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,7 +3,7 @@
   "version": "4.3.0",
   "private": true,
   "scripts": {
-    "demo:basic": "tsnd -r tsconfig-paths/register -r dotenv/config express-basic",
+    "basic": "tsnd -r tsconfig-paths/register -r dotenv/config express-basic",
     "express": "tsnd -r tsconfig-paths/register -r dotenv/config express",
     "gcs": "tsnd -r tsconfig-paths/register -r dotenv/config express-gcs",
     "gcs:direct": "tsnd -r tsconfig-paths/register -r dotenv/config gcs-direct",

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -37,6 +37,7 @@ interface SendParameters {
 
 interface AuthRequest extends http.IncomingMessage {
   [propName: string]: any;
+
   user?: {
     [idKey: string]: any;
     id?: string;
@@ -49,6 +50,7 @@ export abstract class BaseHandler extends EventEmitter implements MethodHandler 
   protected log = Logger.get(this.constructor.name);
   private _registeredHandlers: Map<string, AsyncHandler> = new Map() as Map<string, AsyncHandler>;
   abstract storage: BaseStorage<any, any>;
+
   constructor() {
     super();
 

--- a/packages/core/src/handlers/tus.ts
+++ b/packages/core/src/handlers/tus.ts
@@ -1,4 +1,3 @@
-import * as bytes from 'bytes';
 import * as http from 'http';
 import {
   BaseStorage,
@@ -53,7 +52,7 @@ export class Tus<TFile extends Readonly<File>, L> extends BaseHandler {
       'Tus-Extension': 'creation,creation-with-upload,termination',
       'Tus-Version': TUS_RESUMABLE,
       'Tus-Resumable': TUS_RESUMABLE,
-      'Tus-Max-Size': bytes.parse(this.storage.config.maxUploadSize || 0)
+      'Tus-Max-Size': this.storage.maxUploadSize
     };
     this.send({ res, statusCode: 204, headers });
     return {} as TFile;

--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -66,6 +66,7 @@ export function hasContent(part: Partial<FilePart>): part is HasContent {
 
 export interface Metadata {
   [key: string]: any;
+
   size?: string | number;
   name?: string;
   filetype?: string;

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -41,6 +41,10 @@ export const ERRORS = {
     statusCode: 413,
     message: 'request entity too large'
   },
+  UNSUPPORTED_MEDIA_TYPE: {
+    statusCode: 415,
+    message: 'unsupported media type'
+  },
   TOO_MANY_REQUESTS: {
     statusCode: 429,
     message: 'too many requests'

--- a/test/disk-storage.spec.ts
+++ b/test/disk-storage.spec.ts
@@ -52,7 +52,7 @@ describe('DiskStorage', () => {
       try {
         await storage.create({} as any, { ...testfile, size: 6e10 });
       } catch (error) {
-        expect(error).toHaveProperty('statusCode', 403);
+        expect(error).toHaveProperty('statusCode', 413);
       }
     });
   });

--- a/test/uploadx.spec.ts
+++ b/test/uploadx.spec.ts
@@ -24,24 +24,24 @@ describe('::Uploadx', () => {
   });
 
   describe('POST', () => {
-    it('should 403 (size limit)', async () => {
+    it('should 413 (size limit)', async () => {
       const res = await request(app)
         .post(basePath)
         .set('x-upload-content-type', 'video/mp4')
         .set('x-upload-content-length', (10e10).toString())
         .send({ name: 'file.mp4' })
-        .expect(403);
+        .expect(413);
       expect(res.type).toBe('application/json');
       expect(res.header).not.toHaveProperty('location');
     });
 
-    it('should 403 (unsupported filetype)', async () => {
+    it('should 415 (unsupported filetype)', async () => {
       const res = await request(app)
         .post(basePath)
         .set('x-upload-content-type', 'text/json')
         .set('x-upload-content-length', '3000')
         .send({ name: 'file.json' })
-        .expect(403);
+        .expect(415);
       expect(res.type).toBe('application/json');
       expect(res.header).not.toHaveProperty('location');
     });


### PR DESCRIPTION
example:
```ts
const options = {
  allowMIME: { value: ['video/*'], message: 'Only Video files is supported.', statusCode: 415 },
  maxUploadSize: { value: '1GB', message: 'File is too big.', statusCode: 413 },
};

app.use('/files', uploadx(options);

```