### PR TITLE
feat(core): customizable validators

### DIFF
--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -1,3 +1,5 @@
+// noinspection JSUnusedGlobalSymbols
+
 import type { IncomingMessage } from 'http';
 
 // eslint-disable-next-line no-shadow
@@ -17,14 +19,24 @@ export const enum ERRORS {
   STORAGE_ERROR = 'STORAGE_ERROR',
   TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS',
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
-  UNSUPPORTED_MEDIA_TYPE = 'UNSUPPORTED_MEDIA_TYPE'
+  UNSUPPORTED_MEDIA_TYPE = 'UNSUPPORTED_MEDIA_TYPE',
+  UNPROCESSABLE_ENTITY = 'UNPROCESSABLE_ENTITY'
 }
 
-type ErrorResponses<T = { error: string }> = {
-  [K in ERRORS]: [statusCode: number, body?: T, headers?: Record<string, any>];
+export type ResponseTuple<T = string | Record<string, any>> = [
+  statusCode: number,
+  body?: T,
+  headers?: Record<string, any>
+];
+type DefaultErrorResponses = {
+  [K in ERRORS]: ResponseTuple;
 };
 
-export const ERROR_RESPONSES: ErrorResponses = {
+export type ErrorResponses<T = string | Record<string, any>> = {
+  [error: string]: ResponseTuple<T>;
+} & DefaultErrorResponses;
+
+export const ERROR_RESPONSES: DefaultErrorResponses = {
   BAD_REQUEST: [400, { error: 'bad request' }],
   INVALID_CONTENT_TYPE: [400, { error: 'invalid or missing content-type header' }],
   INVALID_RANGE: [400, { error: 'invalid or missing content-range header' }],
@@ -32,6 +44,7 @@ export const ERROR_RESPONSES: ErrorResponses = {
   INVALID_FILE_NAME: [400, { error: 'file name cannot be retrieved' }],
   FORBIDDEN: [403, { error: 'authenticated user is not allowed access' }],
   FILE_NOT_ALLOWED: [403, { error: 'file not allowed' }],
+  UNPROCESSABLE_ENTITY: [422, { error: 'validation failed' }],
   FILE_CONFLICT: [409, { error: 'file conflict' }],
   REQUEST_ENTITY_TOO_LARGE: [413, { error: 'request entity too large' }],
   UNSUPPORTED_MEDIA_TYPE: [415, { error: 'unsupported media type' }],
@@ -53,9 +66,6 @@ export function isUploadxError(err: unknown): err is UploadxError {
   return (err as UploadxError).uploadxError !== undefined;
 }
 
-export function fail(
-  uploadxError: ERRORS,
-  detail?: Record<string, unknown> | string
-): Promise<never> {
+export function fail(uploadxError: string, detail?: Record<string, any> | string): Promise<never> {
   return Promise.reject({ message: uploadxError, uploadxError, detail });
 }

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -1,87 +1,61 @@
-import { IncomingMessage } from 'http';
+import type { IncomingMessage } from 'http';
 
-/**
- * @beta
- */
-export const ERRORS = {
-  BAD_REQUEST: {
-    statusCode: 400,
-    message: 'bad request'
-  },
-  INVALID_CONTENT_TYPE: {
-    statusCode: 400,
-    message: 'invalid or missing content-type header'
-  },
-  INVALID_RANGE: {
-    statusCode: 400,
-    message: 'invalid or missing content-range header'
-  },
-  INVALID_FILE_SIZE: {
-    statusCode: 400,
-    message: 'file size cannot be retrieved'
-  },
-  INVALID_FILE_NAME: {
-    statusCode: 400,
-    message: 'file name cannot be retrieved'
-  },
-  FORBIDDEN: {
-    statusCode: 403,
-    message: 'authenticated user is not allowed access'
-  },
-  FILE_NOT_ALLOWED: {
-    statusCode: 403,
-    message: 'file not allowed'
-  },
-  FILE_CONFLICT: {
-    statusCode: 409,
-    message: 'file conflict'
-  },
-  REQUEST_ENTITY_TOO_LARGE: {
-    statusCode: 413,
-    message: 'request entity too large'
-  },
-  UNSUPPORTED_MEDIA_TYPE: {
-    statusCode: 415,
-    message: 'unsupported media type'
-  },
-  TOO_MANY_REQUESTS: {
-    statusCode: 429,
-    message: 'too many requests'
-  },
-  FILE_NOT_FOUND: {
-    statusCode: 404,
-    message: 'not found'
-  },
-  GONE: {
-    statusCode: 410,
-    message: 'gone'
-  },
-  UNKNOWN_ERROR: {
-    statusCode: 500,
-    message: 'something went wrong receiving the file'
-  },
-  FILE_ERROR: {
-    statusCode: 500,
-    message: 'something went wrong writing the file'
-  },
-  STORAGE_ERROR: {
-    statusCode: 503,
-    message: 'storage error'
-  }
-};
-
-export interface ErrorInit {
-  statusCode: number;
-  message: string;
+// eslint-disable-next-line no-shadow
+export const enum ERRORS {
+  BAD_REQUEST = 'BAD_REQUEST',
+  FILE_CONFLICT = 'FILE_CONFLICT',
+  FILE_ERROR = 'FILE_ERROR',
+  FILE_NOT_ALLOWED = 'FILE_NOT_ALLOWED',
+  FILE_NOT_FOUND = 'FILE_NOT_FOUND',
+  FORBIDDEN = 'FORBIDDEN',
+  GONE = 'GONE',
+  INVALID_CONTENT_TYPE = 'INVALID_CONTENT_TYPE',
+  INVALID_FILE_NAME = 'INVALID_FILE_NAME',
+  INVALID_FILE_SIZE = 'INVALID_FILE_SIZE',
+  INVALID_RANGE = 'INVALID_RANGE',
+  REQUEST_ENTITY_TOO_LARGE = 'REQUEST_ENTITY_TOO_LARGE',
+  STORAGE_ERROR = 'STORAGE_ERROR',
+  TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS',
+  UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+  UNSUPPORTED_MEDIA_TYPE = 'UNSUPPORTED_MEDIA_TYPE'
 }
 
+type ErrorResponses<T = { error: string }> = {
+  [K in ERRORS]: [statusCode: number, body?: T, headers?: Record<string, any>];
+};
+
+export const ERROR_RESPONSES: ErrorResponses = {
+  BAD_REQUEST: [400, { error: 'bad request' }],
+  INVALID_CONTENT_TYPE: [400, { error: 'invalid or missing content-type header' }],
+  INVALID_RANGE: [400, { error: 'invalid or missing content-range header' }],
+  INVALID_FILE_SIZE: [400, { error: 'file size cannot be retrieved' }],
+  INVALID_FILE_NAME: [400, { error: 'file name cannot be retrieved' }],
+  FORBIDDEN: [403, { error: 'authenticated user is not allowed access' }],
+  FILE_NOT_ALLOWED: [403, { error: 'file not allowed' }],
+  FILE_CONFLICT: [409, { error: 'file conflict' }],
+  REQUEST_ENTITY_TOO_LARGE: [413, { error: 'request entity too large' }],
+  UNSUPPORTED_MEDIA_TYPE: [415, { error: 'unsupported media type' }],
+  TOO_MANY_REQUESTS: [429, { error: 'too many requests' }],
+  FILE_NOT_FOUND: [404, { error: 'not found' }],
+  GONE: [410, { error: 'gone' }],
+  UNKNOWN_ERROR: [500, { error: 'something went wrong receiving the file' }],
+  FILE_ERROR: [500, { error: 'something went wrong writing the file' }],
+  STORAGE_ERROR: [503, { error: 'storage error' }]
+};
+
 export class UploadxError extends Error {
-  statusCode?: number;
-  status?: number;
-  request: Pick<IncomingMessage, 'url' | 'headers' | 'method'> | undefined;
+  uploadxError: ERRORS = ERRORS.UNKNOWN_ERROR;
+  request?: Pick<IncomingMessage, 'url' | 'headers' | 'method'> | undefined;
   detail?: string | Record<string, unknown>;
 }
 
-export function fail(error: ErrorInit, detail?: Record<string, unknown> | string): Promise<never> {
-  return Promise.reject({ ...error, detail });
+export function isUploadxError(err: unknown): err is UploadxError {
+  return (err as UploadxError).uploadxError !== undefined;
+}
+
+export function fail(
+  uploadxError: ERRORS,
+  detail?: Record<string, unknown> | string
+): Promise<never> {
+  return Promise.reject({ message: uploadxError, uploadxError, detail });
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './fs';
 export * from './http';
 export * from './logger';
 export * from './primitives';
+export * from './validator';

--- a/packages/core/src/utils/validator.ts
+++ b/packages/core/src/utils/validator.ts
@@ -1,0 +1,37 @@
+import { ErrorResponses, ERROR_RESPONSES, fail, ResponseTuple } from './errors';
+
+export interface ValidatorConfig<T> {
+  value?: any;
+  isValid?: (t: T) => boolean | Promise<boolean>;
+  response?: ResponseTuple;
+}
+
+export type Validation<T> = Record<string, ValidatorConfig<T>>;
+
+export class Validator<T> {
+  private _validators: Record<string, ValidatorConfig<T>> = {};
+
+  constructor(public errorResponses: ErrorResponses, private prefix = 'validation_') {}
+
+  add(config: Validation<T>): void {
+    for (const [key, validator] of Object.entries(config)) {
+      const code = `${this.prefix}${key}`.toUpperCase();
+      validator.response && (this.errorResponses[code] = validator.response);
+      const entry = (this._validators[code] = { ...this._validators[code], ...validator });
+      if (typeof entry.isValid !== 'function') {
+        throw new Error('Validation config "isValid" is missing or it is not a function!');
+      }
+      if (!entry.response) {
+        this._validators[code].response = ERROR_RESPONSES.UNPROCESSABLE_ENTITY;
+      }
+    }
+  }
+
+  async verify(t: T): Promise<void | never> {
+    for (const [errorCode, validator] of Object.entries(this._validators)) {
+      if (validator.isValid && !(await validator.isValid(t))) {
+        return fail(errorCode);
+      }
+    }
+  }
+}

--- a/test/base-handler.spec.ts
+++ b/test/base-handler.spec.ts
@@ -33,7 +33,10 @@ describe('BaseHandler', () => {
       const sendSpy = jest.spyOn(uploader, 'send');
       const err = new Error('Error Message');
       uploader.sendError(res, err);
-      expect(sendSpy).toHaveBeenCalledWith(res, { statusCode: 500, body: 'Error Message' });
+      expect(sendSpy).toHaveBeenCalledWith(res, {
+        statusCode: 500,
+        body: { error: 'something went wrong receiving the file' }
+      });
     });
 
     it('should send Error (as json)', () => {
@@ -44,7 +47,7 @@ describe('BaseHandler', () => {
       uploader.sendError(res, err);
       expect(sendSpy).toHaveBeenCalledWith(res, {
         statusCode: 500,
-        body: { message: 'Error Message', code: 500, detail: 'Error Message' }
+        body: { error: 'something went wrong receiving the file' }
       });
     });
   });

--- a/test/gcs-storage.spec.ts
+++ b/test/gcs-storage.spec.ts
@@ -68,7 +68,7 @@ describe('GCStorage', () => {
       mockAuthRequest.mockResolvedValue({});
       await expect(
         storage.update(filename, { metadata: { name: 'newname.mp4' } })
-      ).rejects.toHaveProperty('statusCode', 404);
+      ).rejects.toHaveProperty('uploadxError', 'FILE_NOT_FOUND');
     });
   });
   describe('.get()', () => {

--- a/test/s3-storage.spec.ts
+++ b/test/s3-storage.spec.ts
@@ -127,7 +127,7 @@ describe('S3Storage', () => {
       }));
       await expect(
         storage.update(filename, { metadata: { name: 'newname.mp4' } } as any)
-      ).rejects.toHaveProperty('statusCode', 404);
+      ).rejects.toHaveProperty('uploadxError', 'FILE_NOT_FOUND');
     });
   });
   describe('.get()', () => {

--- a/test/validator.spec.ts
+++ b/test/validator.spec.ts
@@ -1,0 +1,49 @@
+import { Validator } from '@uploadx/core';
+
+describe('Validator', () => {
+  type TestObj = { prop: number };
+  const errorResponses = {} as Record<string, any>;
+  let validation: Validator<TestObj>;
+  beforeEach(() => {
+    validation = new Validator<TestObj>(errorResponses as any);
+  });
+  it('simple', async () => {
+    const obj = { prop: 10 };
+    validation.add({
+      first: {
+        isValid: p => p.prop > 20
+      }
+    });
+    await expect(validation.verify(obj)).rejects.toHaveProperty('uploadxError', 'VALIDATION_FIRST');
+  });
+  it('async isValid', async () => {
+    const obj = { prop: 10 };
+    validation.add({
+      first: {
+        isValid: p => Promise.resolve(p.prop > 20)
+      }
+    });
+    await expect(validation.verify(obj)).rejects.toHaveProperty('uploadxError', 'VALIDATION_FIRST');
+  });
+  it('custom response', async () => {
+    const obj = { prop: 10 };
+    validation.add({
+      first: {
+        isValid: p => p.prop > 20,
+        response: [400, 'error']
+      }
+    });
+    expect(errorResponses).toHaveProperty('VALIDATION_FIRST');
+    await expect(validation.verify(obj)).rejects.toHaveProperty('uploadxError', 'VALIDATION_FIRST');
+  });
+
+  it('throw missing isValid', () => {
+    expect(() => {
+      validation.add({
+        first: {
+          response: [400, 'error']
+        }
+      });
+    }).toThrow();
+  });
+});


### PR DESCRIPTION
Allows to tweak existing `size` and `mime` validators and add new ones.

```ts
const storage = new DiskStorage({
  maxUploadSize: '1GB',
  directory: 'upload',
  onComplete,
  validation: {
    mime: { value: ['video/*'], response: [415, { error: 'video only' }] },
    channel: {
      isValid: file => !!file.metadata.channel,
      response: [403, { error: 'missing channel id' }]
    }
  }
});

const uploadx = new Uploadx({ storage });
```