### PR TITLE
fix: configurable metadata size limit

### DIFF
--- a/examples/express.ts
+++ b/examples/express.ts
@@ -23,12 +23,17 @@ const onComplete: OnComplete<DiskFile> = async file => {
 const storage = new DiskStorage({
   maxUploadSize: '1GB',
   directory: 'upload',
+  maxMetadataSize: '1mb',
   onComplete,
   validation: {
     mime: { value: ['video/*'], response: [415, { error: 'video only' }] },
     mtime: {
       isValid: file => !!file.metadata.lastModified,
       response: [403, { error: 'missing lastModified' }]
+    },
+    filename: {
+      isValid: file => file.name.length < 255 && !/[^a-z0-9_.@()-]/i.test(file.name),
+      response: [400, { error: 'invalid filename' }]
     }
   }
 });

--- a/packages/core/src/handlers/uploadx.ts
+++ b/packages/core/src/handlers/uploadx.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import * as url from 'url';
 import { BaseStorage, DiskStorageOptions, File, FileInit } from '../storages';
-import { ERRORS, fail, getBaseUrl, getHeader, getJsonBody } from '../utils';
+import { ERRORS, fail, getBaseUrl, getHeader, getMetadata } from '../utils';
 import { BaseHandler } from './base-handler';
 
 export function rangeParser(rangeHeader = ''): { start: number; total: number } {
@@ -21,7 +21,7 @@ export class Uploadx<TFile extends Readonly<File>, TList> extends BaseHandler<TF
    * Create File from request and send file url to client
    */
   async post(req: http.IncomingMessage, res: http.ServerResponse): Promise<TFile> {
-    const metadata = await getJsonBody(req, this.storage.maxMetadataSize).catch(error =>
+    const metadata = await getMetadata(req, this.storage.maxMetadataSize).catch(error =>
       fail(ERRORS.BAD_REQUEST, error)
     );
     const config: FileInit = { metadata };
@@ -38,7 +38,7 @@ export class Uploadx<TFile extends Readonly<File>, TList> extends BaseHandler<TF
   async patch(req: http.IncomingMessage, res: http.ServerResponse): Promise<TFile> {
     const name = this.getName(req);
     if (!name) return fail(ERRORS.FILE_NOT_FOUND);
-    const metadata = await getJsonBody(req).catch(error => fail(ERRORS.BAD_REQUEST, error));
+    const metadata = await getMetadata(req).catch(error => fail(ERRORS.BAD_REQUEST, error));
     const file = await this.storage.update(name, { metadata, name });
     this.send(res, { body: file.metadata });
     return file;

--- a/packages/core/src/handlers/uploadx.ts
+++ b/packages/core/src/handlers/uploadx.ts
@@ -2,7 +2,7 @@ import * as http from 'http';
 import * as url from 'url';
 import { BaseStorage, DiskStorageOptions, File, FileInit } from '../storages';
 import { ERRORS, fail, getBaseUrl, getHeader, getJsonBody } from '../utils';
-import { BaseHandler, Headers } from './base-handler';
+import { BaseHandler } from './base-handler';
 
 export function rangeParser(rangeHeader = ''): { start: number; total: number } {
   const parts = rangeHeader.split(/\s+|\//);
@@ -21,14 +21,16 @@ export class Uploadx<TFile extends Readonly<File>, TList> extends BaseHandler<TF
    * Create File from request and send file url to client
    */
   async post(req: http.IncomingMessage, res: http.ServerResponse): Promise<TFile> {
-    const metadata = await getJsonBody(req).catch(error => fail(ERRORS.BAD_REQUEST, error));
+    const metadata = await getJsonBody(req, this.storage.maxMetadataSize).catch(error =>
+      fail(ERRORS.BAD_REQUEST, error)
+    );
     const config: FileInit = { metadata };
     config.userId = this.getUserId(req, res);
     config.size = getHeader(req, 'x-upload-content-length');
     config.contentType = getHeader(req, 'x-upload-content-type');
     const file = await this.storage.create(req, config);
     const statusCode = file.bytesWritten > 0 ? 200 : 201;
-    const headers: Headers = { Location: this.buildFileUrl(req, file) };
+    const headers = { Location: this.buildFileUrl(req, file) };
     this.send(res, { statusCode, headers });
     return file;
   }
@@ -53,7 +55,7 @@ export class Uploadx<TFile extends Readonly<File>, TList> extends BaseHandler<TF
     const { start } = contentRange ? rangeParser(contentRange) : { start: 0 };
     const file = await this.storage.write({ start, name, contentLength, body: req });
     if (file.status === 'part') {
-      const headers: Headers = { Range: `bytes=0-${file.bytesWritten - 1}` };
+      const headers = { Range: `bytes=0-${file.bytesWritten - 1}` };
       res.statusMessage = 'Resume Incomplete';
       this.send(res, { statusCode: Uploadx.RESUME_STATUS_CODE, headers });
     }

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -13,6 +13,7 @@ import {
 import { File, FileInit, FilePart } from './file';
 
 export const METAFILE_EXTNAME = '.META';
+const MAX_FILENAME_LENGTH = 255 - METAFILE_EXTNAME.length;
 
 export type OnComplete<T extends File> = (file: T) => any;
 
@@ -84,7 +85,7 @@ export abstract class BaseStorage<TFile extends File, TList> {
     };
     const filename: ValidatorConfig<TFile> = {
       isValid(file) {
-        return file.name.length < 255;
+        return file.name.length < MAX_FILENAME_LENGTH;
       },
       response: ERROR_RESPONSES.INVALID_FILE_NAME
     };

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -29,6 +29,7 @@ export interface BaseStorageOptions<T extends File> {
   /** Node http base path */
   path?: string;
   validation?: Validation<T>;
+  maxMetadataSize?: number | string;
 }
 
 const defaultOptions: Required<BaseStorageOptions<File>> = {
@@ -38,12 +39,14 @@ const defaultOptions: Required<BaseStorageOptions<File>> = {
   useRelativeLocation: false,
   onComplete: () => null,
   path: '/files',
-  validation: {}
+  validation: {},
+  maxMetadataSize: '16MB'
 };
 
 export abstract class BaseStorage<TFile extends File, TList> {
   onComplete: (file: TFile) => Promise<any> | any;
   maxUploadSize: number;
+  maxMetadataSize: number;
   path: string;
   isReady = false;
   errorResponses = {} as ErrorResponses;
@@ -58,6 +61,7 @@ export abstract class BaseStorage<TFile extends File, TList> {
     this.onComplete = opts.onComplete;
     this.namingFunction = opts.filename;
     this.maxUploadSize = bytes.parse(opts.maxUploadSize);
+    this.maxMetadataSize = bytes.parse(opts.maxMetadataSize);
 
     const size: Required<ValidatorConfig<TFile>> = {
       value: this.maxUploadSize,

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -41,7 +41,7 @@ const defaultOptions: Required<BaseStorageOptions<File>> = {
   onComplete: () => null,
   path: '/files',
   validation: {},
-  maxMetadataSize: '16MB'
+  maxMetadataSize: '2MB'
 };
 
 export abstract class BaseStorage<TFile extends File, TList> {

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -82,7 +82,13 @@ export abstract class BaseStorage<TFile extends File, TList> {
       },
       response: ERROR_RESPONSES.UNSUPPORTED_MEDIA_TYPE
     };
-    this.validation.add({ size, mime });
+    const filename: ValidatorConfig<TFile> = {
+      isValid(file) {
+        return file.name.length < 255;
+      },
+      response: ERROR_RESPONSES.INVALID_FILE_NAME
+    };
+    this.validation.add({ size, mime, filename });
     this.validation.add({ ...opts.validation });
   }
 

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -46,7 +46,7 @@ export const ERROR_RESPONSES: DefaultErrorResponses = {
   FORBIDDEN: [403, { error: 'authenticated user is not allowed access' }],
   GONE: [410, { error: 'gone' }],
   INVALID_CONTENT_TYPE: [400, { error: 'invalid or missing content-type header' }],
-  INVALID_FILE_NAME: [400, { error: 'file name cannot be retrieved' }],
+  INVALID_FILE_NAME: [400, { error: 'invalid file name or it cannot be retrieved' }],
   INVALID_FILE_SIZE: [400, { error: 'file size cannot be retrieved' }],
   INVALID_RANGE: [400, { error: 'invalid or missing content-range header' }],
   METHOD_NOT_ALLOWED: [405, { error: 'method not allowed' }],

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -42,7 +42,7 @@ export async function getJsonBody(
 }
 
 export function getHeader(req: http.IncomingMessage, name: string): string {
-  const raw = req?.headers?.[name.toLowerCase()];
+  const raw = req.headers?.[name.toLowerCase()];
   return Array.isArray(raw) ? raw[0] : raw || '';
 }
 


### PR DESCRIPTION
Allows  to control the maximum size of the metadata, for example in case of large base64-encoded pictures in the metadata.