### PR TITLE
fix: lock completed files

### DIFF
--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -146,10 +146,11 @@ export class GCStorage extends BaseStorage<GCSFile, CGSObject> {
 
   async write(part: FilePart): Promise<GCSFile> {
     const file = await this._getMeta(part.name);
+    if (file.status === 'completed') return file;
     if (!isValidPart(part, file)) return fail(ERRORS.FILE_CONFLICT);
     file.bytesWritten = await this._write({ ...file, ...part });
     updateStatus(file);
-    if (file.status === 'completed') {
+    if (file.status === ('completed' as any)) {
       file.uri = `${this.storageBaseURI}/${file.name}`;
       await this._onComplete(file);
     }

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -99,6 +99,7 @@ export class S3Storage extends BaseStorage<S3File, any> {
 
   async write(part: FilePart): Promise<S3File> {
     const file = await this._getMeta(part.name);
+    if (file.status === 'completed') return file;
     if (!isValidPart(part, file)) return fail(ERRORS.FILE_CONFLICT);
     file.Parts ||= [];
     if (hasContent(part)) {
@@ -118,7 +119,7 @@ export class S3Storage extends BaseStorage<S3File, any> {
       this.cache.set(file.name, file);
     }
     updateStatus(file);
-    if (file.status === 'completed') {
+    if (file.status === ('completed' as any)) {
       const [completed] = await this._onComplete(file);
       file.uri = completed.Location;
     }


### PR DESCRIPTION
Prevents a completed file from being reuploaded after it has been moved or deleted.

https://github.com/Chocobozzz/PeerTube/issues/3661#issuecomment-875224445