### PR TITLE
feat(storage): metastorage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,21 +83,23 @@ Please navigate to the [examples](examples) for more.
 
 ### 🛠 Options
 
-Available options are:
+Some available options: :
 
-| option                |       type       |  default value   | description                                         |
-| :-------------------- | :--------------: | :--------------: | --------------------------------------------------- |
-| `directory`           |     `string`     |    `"files"`     | _DiskStorage upload directory_                      |
-| `bucket`              |     `string`     | `"node-uploadx"` | _S3 or GCS bucket_                                  |
-| `path`                |     `string`     |    `"/files"`    | _Node http base path_                               |
-| `allowMIME`           |    `string[]`    |    `["*\*"]`     | _Allowed MIME types_                                |
-| `maxUploadSize`       | `string\|number` |     `"5TB"`      | _File size limit_                                   |
-| `maxMetadataSize`     | `string\|number` |     `"4MB"`      | _Metadata size limit_                               |
-| `validation`          |     `Object`     |                  | _Upload validation options_                         |
-| `useRelativeLocation` |    `boolean`     |     `false`      | _Use relative urls_                                 |
-| `filename`            |    `Function`    |                  | _Name generator function_                           |
-| `onComplete`          |    `Function`    |                  | _On upload complete callback_                       |
-| `clientDirectUpload`  |    `boolean`     |                  | _Upload by a compatible client directly to the GCS_ |
+| option                |         type         |  default value   | description                                         |
+| :-------------------- | :------------------: | :--------------: | --------------------------------------------------- |
+| `directory`           |       `string`       |    `"files"`     | _DiskStorage upload directory_                      |
+| `bucket`              |       `string`       | `"node-uploadx"` | _S3 or GCS bucket_                                  |
+| `path`                |       `string`       |    `"/files"`    | _Node http base path_                               |
+| `allowMIME`           |      `string[]`      |    `["*\*"]`     | _Allowed MIME types_                                |
+| `maxUploadSize`       |   `string\|number`   |     `"5TB"`      | _File size limit_                                   |
+| `metaStorage`         |    `MetaStorage`     |                  | _Provide custom meta storage_                       |
+| `metaStorageConfig`   | `MetaStorageOptions` |                  | _Configure metafiles storage_                       |
+| `maxMetadataSize`     |   `string\|number`   |     `"4MB"`      | _Metadata size limit_                               |
+| `validation`          |     `Validation`     |                  | _Upload validation options_                         |
+| `useRelativeLocation` |      `boolean`       |     `false`      | _Use relative urls_                                 |
+| `filename`            |      `Function`      |                  | _Name generator function_                           |
+| `onComplete`          |     `OnComplete`     |                  | _On upload complete callback_                       |
+| `clientDirectUpload`  |      `boolean`       |                  | _Upload by a compatible client directly to the GCS_ |
 
 For Google Cloud Storage authenticate see [GoogleAuthOptions](https://github.com/googleapis/google-auth-library-nodejs/blob/04dae9c271f0099025188489c61fd245d482832b/src/auth/googleauth.ts#L62). Also supported `GCS_BUCKET`, `GCS_KEYFILE` and `GOOGLE_APPLICATION_CREDENTIALS` environment variables.
 

--- a/examples/express-s3.js
+++ b/examples/express-s3.js
@@ -7,7 +7,22 @@ function onComplete(file) {
   console.log('File upload complete: ', file);
 }
 
-const storage = new S3Storage({ bucket: 'node-uploadx', onComplete });
+// const storage = new S3Storage({
+//   bucket: <YOUR_BUCKET>,
+//   endpoint: <YOUR_ENDPOINT>,
+//   region: <YOUR_REGION>,
+//   credentials: {
+//     accessKeyId: <YOUR_ACCESS_KEY_ID>,
+//     secretAccessKey: <YOUR_SECRET_ACCESS_KEY>
+//   },
+//   metaStorageConfig: { directory: 'upload' }
+// });
+
+// The credentials are loaded from a shared credentials file
+const storage = new S3Storage({
+  bucket: 'node-uploadx',
+  onComplete
+});
 
 app.use('/files', tus({ storage }));
 

--- a/examples/gcs-direct.ts
+++ b/examples/gcs-direct.ts
@@ -1,12 +1,17 @@
+import { MetaStorage, Uploadx } from '@uploadx/core';
+import { GCStorage } from '@uploadx/gcs';
 import { createServer } from 'http';
 import { parse } from 'url';
-import { GCStorage, Uploadx } from 'node-uploadx';
 
+// Don't forget to set GCS_BUCKET and GCS_KEYFILE environment variables
 const storage = new GCStorage({
   clientDirectUpload: true,
   maxUploadSize: '15GB',
-  allowMIME: ['video/*', 'image/*']
+  allowMIME: ['video/*', 'image/*'],
+  filename: file => file.originalName,
+  metaStorage: new MetaStorage()
 });
+
 const uploads = new Uploadx({ storage });
 uploads.on('created', file =>
   console.log('google upload link sent to client: ', file.GCSUploadURI)
@@ -14,7 +19,7 @@ uploads.on('created', file =>
 
 createServer((req, res) => {
   const { pathname } = parse(req.url || '');
-  if (pathname === '/upload/files') {
+  if (pathname === '/upload') {
     uploads.handle(req, res);
   } else {
     res.writeHead(404, { 'Content-Type': 'text/plan' });

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -57,7 +57,6 @@ export abstract class BaseHandler<TFile extends Readonly<File>>
    * @example
    * Uploadx.methods = ['post', 'put', 'delete'];
    * app.use('/upload', uploadx(opts));
-   *
    */
   static methods: Handlers[] = ['delete', 'get', 'head', 'options', 'patch', 'post', 'put'];
   cors: Cors;
@@ -87,7 +86,6 @@ export abstract class BaseHandler<TFile extends Readonly<File>>
    *  uploadx.errorResponses = {
    *    FileNotFound: [404, { message: 'Not Found!' }]
    *  }
-   * @param value
    */
   set errorResponses(value: Partial<ErrorResponses>) {
     this.assembleErrors(value);

--- a/packages/core/src/handlers/multipart.ts
+++ b/packages/core/src/handlers/multipart.ts
@@ -12,7 +12,7 @@ interface MultipartyPart extends multiparty.Part {
   };
 }
 
-export class Multipart<TFile extends Readonly<File>, TList> extends BaseHandler<TFile, TList> {
+export class Multipart<TFile extends Readonly<File>> extends BaseHandler<TFile> {
   async post(req: http.IncomingMessage, res: http.ServerResponse): Promise<TFile> {
     return new Promise((resolve, reject) => {
       const form = new multiparty.Form();
@@ -66,8 +66,8 @@ export class Multipart<TFile extends Readonly<File>, TList> extends BaseHandler<
 /**
  * Basic express wrapper
  */
-export function multipart<TFile extends Readonly<File>, TList>(
-  options: DiskStorageOptions | { storage: BaseStorage<TFile, TList> } = {}
+export function multipart<TFile extends Readonly<File>>(
+  options: DiskStorageOptions | { storage: BaseStorage<TFile> } = {}
 ): (req: http.IncomingMessage, res: http.ServerResponse) => void {
   return new Multipart(options).handle;
 }

--- a/packages/core/src/handlers/tus.ts
+++ b/packages/core/src/handlers/tus.ts
@@ -27,7 +27,7 @@ export function parseMetadata(encoded = ''): Metadata {
  * tus resumable upload protocol
  * @link https://github.com/tus/tus-resumable-upload-protocol/blob/master/protocol.md
  */
-export class Tus<TFile extends Readonly<File>, TList> extends BaseHandler<TFile, TList> {
+export class Tus<TFile extends Readonly<File>> extends BaseHandler<TFile> {
   /**
    *
    */
@@ -137,8 +137,8 @@ export class Tus<TFile extends Readonly<File>, TList> extends BaseHandler<TFile,
  * @example
  * app.use('/files', tus({directory: '/tmp', maxUploadSize: '250GB'}));
  */
-export function tus<TFile extends File, TList>(
-  options: DiskStorageOptions | { storage: BaseStorage<TFile, TList> } = {}
+export function tus<TFile extends File>(
+  options: DiskStorageOptions | { storage: BaseStorage<TFile> } = {}
 ): (req: http.IncomingMessage, res: http.ServerResponse) => void {
   return new Tus(options).handle;
 }
@@ -156,6 +156,6 @@ export function tus<TFile extends File, TList>(
   return res.sendStatus(204);
 });
  */
-tus.upload = <TFile extends Readonly<File>, TList>(
-  options: DiskStorageOptions | { storage: BaseStorage<TFile, TList> }
+tus.upload = <TFile extends Readonly<File>>(
+  options: DiskStorageOptions | { storage: BaseStorage<TFile> }
 ) => new Tus(options).upload;

--- a/packages/core/src/handlers/uploadx.ts
+++ b/packages/core/src/handlers/uploadx.ts
@@ -14,11 +14,11 @@ export function rangeParser(rangeHeader = ''): { start: number; total: number } 
 /**
  * X-headers protocol implementation
  */
-export class Uploadx<TFile extends Readonly<File>, TList> extends BaseHandler<TFile, TList> {
+export class Uploadx<TFile extends Readonly<File>> extends BaseHandler<TFile> {
   static RESUME_STATUS_CODE = 308;
 
   /**
-   * Create File from request and send file url to client
+   * Create File from request and send a file url to client
    */
   async post(req: http.IncomingMessage, res: http.ServerResponse): Promise<TFile> {
     const metadata = await getMetadata(req, this.storage.maxMetadataSize).catch(error =>
@@ -47,7 +47,7 @@ export class Uploadx<TFile extends Readonly<File>, TList> extends BaseHandler<TF
   }
 
   /**
-   * Write chunk to file or/and return chunk offset
+   * Write a chunk to file or/and return chunk offset
    */
   async put(req: http.IncomingMessage, res: http.ServerResponse): Promise<TFile> {
     const name = this.getName(req);
@@ -104,8 +104,8 @@ export class Uploadx<TFile extends Readonly<File>, TList> extends BaseHandler<TF
  * @example
  * app.use('/files', uploadx({directory: '/tmp', maxUploadSize: '250GB'}));
  */
-export function uploadx<TFile extends Readonly<File>, TList>(
-  options: DiskStorageOptions | { storage: BaseStorage<TFile, TList> } = {}
+export function uploadx<TFile extends Readonly<File>>(
+  options: DiskStorageOptions | { storage: BaseStorage<TFile> } = {}
 ): (req: http.IncomingMessage, res: http.ServerResponse) => void {
   return new Uploadx(options).handle;
 }
@@ -123,6 +123,6 @@ export function uploadx<TFile extends Readonly<File>, TList>(
   return res.json(req.body);
 });
  */
-uploadx.upload = <TFile extends Readonly<File>, TList>(
-  options: DiskStorageOptions | { storage: BaseStorage<TFile, TList> }
+uploadx.upload = <TFile extends Readonly<File>>(
+  options: DiskStorageOptions | { storage: BaseStorage<TFile> }
 ) => new Uploadx(options).upload;

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -12,7 +12,7 @@ import {
 } from './file';
 import { BaseStorage, BaseStorageOptions } from './storage';
 import { METAFILE_EXTNAME, MetaStorage } from './meta-storage';
-import { LocalMetaStorage } from './local-meta-storage';
+import { LocalMetaStorage, LocalMetaStorageOptions } from './local-meta-storage';
 
 const INVALID_OFFSET = -1;
 
@@ -24,6 +24,7 @@ export type DiskStorageOptions = BaseStorageOptions<DiskFile> & {
    * @defaultValue './files'
    */
   directory?: string;
+  metaStorageConfig?: LocalMetaStorageOptions;
 };
 
 /**
@@ -36,9 +37,12 @@ export class DiskStorage extends BaseStorage<DiskFile> {
   constructor(public config: DiskStorageOptions = {}) {
     super(config);
     this.directory = config.directory || this.path.replace(/^\//, '');
-    this.meta = config.metaStorage
-      ? config.metaStorage
-      : new LocalMetaStorage({ metaStoragePath: config.metaStoragePath ?? this.directory });
+    if (config.metaStorage) {
+      this.meta = config.metaStorage;
+    } else {
+      const metaConfig = { ...config, ...(config.metaStorageConfig || {}) };
+      this.meta = new LocalMetaStorage(metaConfig);
+    }
     this.isReady = true;
     this.maxFilenameLength = 255 - pathResolve(this.directory, METAFILE_EXTNAME).length;
   }

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -16,6 +16,14 @@ export type DiskStorageOptions = BaseStorageOptions<DiskFile> & {
    * @defaultValue './files'
    */
   directory?: string;
+  /**
+   * Configuring metafile storage on the local disk
+   * @example
+   * const storage = new DiskStorage({
+   *   directory: 'upload',
+   *   metaStorageConfig: { directory: '/tmp/upload-metafiles', prefix: '.' }
+   * })
+   */
   metaStorageConfig?: LocalMetaStorageOptions;
 };
 

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -1,15 +1,7 @@
 import * as http from 'http';
 import { resolve as pathResolve } from 'path';
 import { ensureFile, ERRORS, fail, fsp, getWriteStream, HttpError } from '../utils';
-import {
-  File,
-  FileInit,
-  FilePart,
-  hasContent,
-  isCompleted,
-  isValidPart,
-  updateMetadata
-} from './file';
+import { File, FileInit, FilePart, hasContent, isCompleted, isValidPart } from './file';
 import { BaseStorage, BaseStorageOptions } from './storage';
 import { METAFILE_EXTNAME, MetaStorage } from './meta-storage';
 import { LocalMetaStorage, LocalMetaStorageOptions } from './local-meta-storage';
@@ -90,17 +82,6 @@ export class DiskStorage extends BaseStorage<DiskFile> {
       return [{ ...file, status: 'deleted' }];
     }
     return [{ name } as DiskFile];
-  }
-
-  /**
-   * @inheritdoc
-   * @todo Metadata size limit
-   */
-  async update(name: string, { metadata }: Partial<DiskFile>): Promise<DiskFile> {
-    const file = await this.getMeta(name);
-    updateMetadata(file, metadata);
-    await this.saveMeta(file);
-    return { ...file, status: 'updated' };
   }
 
   /**

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
-import { extname, join, relative, resolve as pathResolve } from 'path';
-import { ensureFile, ERRORS, fail, fsp, getFiles, getWriteStream, HttpError } from '../utils';
+import { resolve as pathResolve } from 'path';
+import { ensureFile, ERRORS, fail, fsp, getWriteStream, HttpError } from '../utils';
 import {
   File,
   FileInit,
@@ -10,7 +10,9 @@ import {
   isValidPart,
   updateMetadata
 } from './file';
-import { BaseStorage, BaseStorageOptions, METAFILE_EXTNAME } from './storage';
+import { BaseStorage, BaseStorageOptions } from './storage';
+import { METAFILE_EXTNAME, MetaStorage } from './meta-storage';
+import { LocalMetaStorage } from './local-meta-storage';
 
 const INVALID_OFFSET = -1;
 
@@ -33,10 +35,14 @@ export type DiskStorageOptions = BaseStorageOptions<DiskFile> & {
  */
 export class DiskStorage extends BaseStorage<DiskFile, DiskListObject> {
   directory: string;
+  meta: MetaStorage<DiskFile>;
 
   constructor(public config: DiskStorageOptions = {}) {
     super(config);
     this.directory = config.directory || this.path.replace(/^\//, '');
+    this.meta = config.metaStorage
+      ? config.metaStorage
+      : new LocalMetaStorage({ metaStoragePath: config.metaStoragePath ?? this.directory });
     this.isReady = true;
     this.maxFilenameLength = 255 - pathResolve(this.directory, METAFILE_EXTNAME).length;
   }
@@ -49,20 +55,22 @@ export class DiskStorage extends BaseStorage<DiskFile, DiskListObject> {
     const file = new DiskFile(fileInit);
     file.name = this.namingFunction(file);
     await this.validate(file);
-    await this._saveMeta(file);
+    const path = this.getFilePath(file.name);
+    file.bytesWritten = await ensureFile(path).catch(e => fail(ERRORS.FILE_ERROR, e));
+    await this.saveMetaFile(file);
     file.status = 'created';
     return file;
   }
 
   async write(part: FilePart): Promise<DiskFile> {
-    const file = await this._getMeta(part.name);
+    const file = await this.getMetaFile(part.name);
     if (file.status === 'completed') return file;
     if (!isValidPart(part, file)) return fail(ERRORS.FILE_CONFLICT);
     try {
       file.bytesWritten = await this._write({ ...file, ...part });
       if (file.bytesWritten === INVALID_OFFSET) return fail(ERRORS.FILE_CONFLICT);
       if (isCompleted(file)) {
-        await this._saveMeta(file);
+        await this.saveMetaFile(file);
       }
       return file;
     } catch (err) {
@@ -71,21 +79,17 @@ export class DiskStorage extends BaseStorage<DiskFile, DiskListObject> {
   }
 
   async get(prefix = ''): Promise<DiskListObject[]> {
-    const files = await getFiles(join(this.directory, prefix));
-    const props = (path: string): DiskListObject => ({
-      name: relative(this.directory, path).replace(/\\/g, '/')
-    });
-    return files.filter(name => extname(name) !== METAFILE_EXTNAME).map(path => props(path));
+    return this.meta.list(prefix);
   }
 
   /**
    * @todo delete by prefix
    */
   async delete(name: string): Promise<DiskFile[]> {
-    const file = await this._getMeta(name).catch(() => null);
+    const file = await this.getMetaFile(name).catch(() => null);
     if (file) {
-      await fsp.unlink(this._getPath(name)).catch(() => null);
-      await this._deleteMeta(name);
+      await fsp.unlink(this.getFilePath(name)).catch(() => null);
+      await this.deleteMetaFile(name);
       return [{ ...file, status: 'deleted' }];
     }
     return [{ name } as DiskFile];
@@ -95,15 +99,19 @@ export class DiskStorage extends BaseStorage<DiskFile, DiskListObject> {
    *@todo Metadata size limit
    */
   async update(name: string, { metadata }: Partial<DiskFile>): Promise<DiskFile> {
-    const file = await this._getMeta(name);
+    const file = await this.getMetaFile(name);
     updateMetadata(file, metadata);
-    await this._saveMeta(file);
+    await this.saveMetaFile(file);
     return { ...file, status: 'updated' };
+  }
+
+  getFilePath(name: string): string {
+    return pathResolve(this.directory, name);
   }
 
   protected _write(part: FilePart & File): Promise<number> {
     return new Promise((resolve, reject) => {
-      const path = this._getPath(part.name);
+      const path = this.getFilePath(part.name);
       if (hasContent(part)) {
         const file = getWriteStream(path, part.start);
         file.once('error', error => reject(error));
@@ -125,39 +133,5 @@ export class DiskStorage extends BaseStorage<DiskFile, DiskListObject> {
         resolve(ensureFile(path));
       }
     });
-  }
-
-  protected async _saveMeta(file: DiskFile): Promise<DiskFile> {
-    const path = this._getPath(file.name);
-    file.bytesWritten = await ensureFile(path).catch(e => fail(ERRORS.FILE_ERROR, e));
-    await fsp.writeFile(this._getMetaPath(file.name), JSON.stringify(file, null, 2));
-    this.cache.set(file.name, file);
-    return file;
-  }
-
-  protected async _deleteMeta(name: string): Promise<void> {
-    this.cache.delete(name);
-    await fsp.unlink(this._getMetaPath(name));
-    return;
-  }
-
-  protected async _getMeta(name: string): Promise<DiskFile> {
-    let file = this.cache.get(name);
-    if (file) return file;
-    try {
-      const json = await fsp.readFile(this._getMetaPath(name), { encoding: 'utf8' });
-      file = JSON.parse(json) as DiskFile;
-      this.cache.set(name, file);
-      return file;
-    } catch {}
-    return fail(ERRORS.FILE_NOT_FOUND);
-  }
-
-  protected _getPath(name: string): string {
-    return pathResolve(this.directory, name);
-  }
-
-  protected _getMetaPath(name: string): string {
-    return this._getPath(name) + METAFILE_EXTNAME;
   }
 }

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -18,10 +18,6 @@ const INVALID_OFFSET = -1;
 
 export class DiskFile extends File {}
 
-export interface DiskListObject {
-  name: string;
-}
-
 export type DiskStorageOptions = BaseStorageOptions<DiskFile> & {
   /**
    * Uploads directory
@@ -33,7 +29,7 @@ export type DiskStorageOptions = BaseStorageOptions<DiskFile> & {
 /**
  * Local Disk Storage
  */
-export class DiskStorage extends BaseStorage<DiskFile, DiskListObject> {
+export class DiskStorage extends BaseStorage<DiskFile> {
   directory: string;
   meta: MetaStorage<DiskFile>;
 
@@ -76,10 +72,6 @@ export class DiskStorage extends BaseStorage<DiskFile, DiskListObject> {
     } catch (err) {
       return fail(ERRORS.FILE_ERROR, err);
     }
-  }
-
-  async get(prefix = ''): Promise<DiskListObject[]> {
-    return this.meta.list(prefix);
   }
 
   /**

--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -68,6 +68,7 @@ export function isValidPart(part: FilePart, file: File): boolean {
   return (part.start || 0) + (part.contentLength || 0) <= file.size;
 }
 
+/** User-provided metadata */
 export interface Metadata {
   [key: string]: any;
 

--- a/packages/core/src/storages/index.ts
+++ b/packages/core/src/storages/index.ts
@@ -1,3 +1,5 @@
 export * from './disk-storage';
 export * from './file';
 export * from './storage';
+export * from './local-meta-storage';
+export * from './meta-storage';

--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -56,7 +56,10 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
     const files = await getFiles(`${this.directory}/${this.prefix + prefix}`);
     for (const name of files) {
       name.endsWith(this.suffix) &&
-        uploads.push({ name: this.getNameFromPath(name), updated: (await fsp.stat(name)).mtime });
+        uploads.push({
+          name: this.getNameFromPath(name),
+          created: (await fsp.stat(name)).ctime
+        });
     }
     return { items: uploads };
   }

--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -1,0 +1,54 @@
+import { join } from 'path';
+import { fsp, getFiles } from '../utils';
+import { File } from './file';
+import { ListObject, MetaStorage, MetaStorageOptions } from './meta-storage';
+import { tmpdir } from 'os';
+
+interface LocalMetaStorageOptions extends MetaStorageOptions {
+  directory?: string;
+  metaStoragePath?: string;
+}
+
+export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
+  public directory = '';
+
+  constructor(readonly config?: LocalMetaStorageOptions) {
+    super();
+
+    this.directory =
+      config?.metaStoragePath ||
+      process.env.UPLOADX_META_DIR ||
+      config?.directory ||
+      join(tmpdir(), 'uploadx_meta');
+  }
+
+  getMetaPath = (name: string): string => `${this.directory}/${this.prefix + name + this.suffix}`;
+
+  getNameFromPath = (metaFilePath: string): string =>
+    metaFilePath.slice(`${this.directory}/${this.prefix}`.length, -this.suffix.length);
+
+  async set(name: string, file: T): Promise<T> {
+    await fsp.writeFile(this.getMetaPath(file.name), JSON.stringify(file, null, 2));
+    return file;
+  }
+
+  async get(name: string): Promise<T> {
+    const json = await fsp.readFile(this.getMetaPath(name), { encoding: 'utf8' });
+    return JSON.parse(json) as T;
+  }
+
+  async remove(name: string): Promise<void> {
+    await fsp.unlink(this.getMetaPath(name));
+    return;
+  }
+
+  async list(prefix = ''): Promise<ListObject[]> {
+    const list = [];
+    const files = await getFiles(`${this.directory}/${this.prefix + prefix}`);
+    for (const name of files) {
+      name.endsWith(this.suffix) &&
+        list.push({ name: this.getNameFromPath(name), updated: (await fsp.stat(name)).mtime });
+    }
+    return list;
+  }
+}

--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -19,8 +19,11 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
 
   constructor(config?: LocalMetaStorageOptions) {
     super(config);
-    this.directory =
-      process.env.UPLOADX_META_DIR || config?.directory || join(tmpdir(), 'uploadx_meta');
+    this.directory = (
+      process.env.UPLOADX_META_DIR ||
+      config?.directory ||
+      join(tmpdir(), 'uploadx_meta')
+    ).replace(/\\/g, '/');
   }
 
   /**

--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -5,12 +5,21 @@ import { UploadList, MetaStorage, MetaStorageOptions } from './meta-storage';
 import { tmpdir } from 'os';
 
 interface LocalMetaStorageOptions extends MetaStorageOptions {
+  /**
+   * Where the upload metadata should be stored
+   */
   directory?: string;
+  /**
+   * Where the upload metadata should be stored
+   */
   metaStoragePath?: string;
 }
 
+/**
+ * Stores upload metafiles on local disk
+ */
 export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
-  public directory = '';
+  readonly directory: string;
 
   constructor(readonly config?: LocalMetaStorageOptions) {
     super();
@@ -22,12 +31,20 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
       join(tmpdir(), 'uploadx_meta');
   }
 
+  /**
+   * Returns metafile path
+   * @param name upload name
+   */
   getMetaPath = (name: string): string => `${this.directory}/${this.prefix + name + this.suffix}`;
 
+  /**
+   * Returns upload name from metafile path
+   * @internal
+   */
   getNameFromPath = (metaFilePath: string): string =>
     metaFilePath.slice(`${this.directory}/${this.prefix}`.length, -this.suffix.length);
 
-  async set(name: string, file: T): Promise<T> {
+  async save(name: string, file: T): Promise<T> {
     await fsp.writeFile(this.getMetaPath(file.name), JSON.stringify(file, null, 2));
     return file;
   }
@@ -37,7 +54,7 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
     return JSON.parse(json) as T;
   }
 
-  async remove(name: string): Promise<void> {
+  async delete(name: string): Promise<void> {
     await fsp.unlink(this.getMetaPath(name));
     return;
   }

--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { fsp, getFiles } from '../utils';
 import { File } from './file';
-import { ListObject, MetaStorage, MetaStorageOptions } from './meta-storage';
+import { UploadList, MetaStorage, MetaStorageOptions } from './meta-storage';
 import { tmpdir } from 'os';
 
 interface LocalMetaStorageOptions extends MetaStorageOptions {
@@ -42,13 +42,13 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
     return;
   }
 
-  async list(prefix = ''): Promise<ListObject[]> {
-    const list = [];
+  async list(prefix = ''): Promise<UploadList> {
+    const uploads = [];
     const files = await getFiles(`${this.directory}/${this.prefix + prefix}`);
     for (const name of files) {
       name.endsWith(this.suffix) &&
-        list.push({ name: this.getNameFromPath(name), updated: (await fsp.stat(name)).mtime });
+        uploads.push({ name: this.getNameFromPath(name), updated: (await fsp.stat(name)).mtime });
     }
-    return list;
+    return { items: uploads };
   }
 }

--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -1,18 +1,14 @@
 import { join } from 'path';
 import { fsp, getFiles } from '../utils';
 import { File } from './file';
-import { UploadList, MetaStorage, MetaStorageOptions } from './meta-storage';
+import { MetaStorage, MetaStorageOptions, UploadList } from './meta-storage';
 import { tmpdir } from 'os';
 
-interface LocalMetaStorageOptions extends MetaStorageOptions {
+export interface LocalMetaStorageOptions extends MetaStorageOptions {
   /**
    * Where the upload metadata should be stored
    */
   directory?: string;
-  /**
-   * Where the upload metadata should be stored
-   */
-  metaStoragePath?: string;
 }
 
 /**
@@ -21,19 +17,15 @@ interface LocalMetaStorageOptions extends MetaStorageOptions {
 export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
   readonly directory: string;
 
-  constructor(readonly config?: LocalMetaStorageOptions) {
-    super();
-
+  constructor(config?: LocalMetaStorageOptions) {
+    super(config);
     this.directory =
-      config?.metaStoragePath ||
-      process.env.UPLOADX_META_DIR ||
-      config?.directory ||
-      join(tmpdir(), 'uploadx_meta');
+      process.env.UPLOADX_META_DIR || config?.directory || join(tmpdir(), 'uploadx_meta');
   }
 
   /**
    * Returns metafile path
-   * @param name upload name
+   * @param name - upload name
    */
   getMetaPath = (name: string): string => `${this.directory}/${this.prefix + name + this.suffix}`;
 

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -1,0 +1,34 @@
+export interface ListObject {
+  name: string;
+  updated?: Date | number | string;
+}
+export interface MetaStorageOptions {
+  prefix?: string;
+  suffix?: string;
+}
+export class MetaStorage<T> {
+  prefix = '';
+  suffix = METAFILE_EXTNAME;
+  constructor(readonly config?: MetaStorageOptions) {
+    this.prefix = config?.prefix ?? '';
+    this.suffix = config?.suffix ?? METAFILE_EXTNAME;
+  }
+
+  async set(name: string, file: T): Promise<T> {
+    return file;
+  }
+
+  async remove(name: string): Promise<void> {
+    return;
+  }
+
+  async get(name: string): Promise<T> {
+    return Promise.reject();
+  }
+
+  async list(prefix: string): Promise<ListObject[]> {
+    return Promise.reject();
+  }
+}
+
+export const METAFILE_EXTNAME = '.META';

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -4,10 +4,14 @@ export interface UploadList {
     updated?: Date | number | string;
   }[];
 }
+
 export interface MetaStorageOptions {
   prefix?: string;
   suffix?: string;
 }
+/**
+ * Stores upload metadata
+ */
 export class MetaStorage<T> {
   prefix = '';
   suffix = METAFILE_EXTNAME;
@@ -16,21 +20,35 @@ export class MetaStorage<T> {
     this.suffix = config?.suffix ?? METAFILE_EXTNAME;
   }
 
-  async set(name: string, file: T): Promise<T> {
+  /**
+   * Saves upload metadata
+   */
+  async save(name: string, file: T): Promise<T> {
     return file;
   }
 
-  async remove(name: string): Promise<void> {
+  /**
+   * Deletes an upload metadata
+   */
+  async delete(name: string): Promise<void> {
     return;
   }
 
+  /**
+   * Retrieves upload metadata
+   */
   async get(name: string): Promise<T> {
     return Promise.reject();
   }
 
-  async list(prefix: string): Promise<UploadList> {
+  /**
+   * Retrieves a list of uploads whose names begin with the prefix
+   */
+  async list(prefix = ''): Promise<UploadList> {
     return { items: [] };
   }
 }
-
+/**
+ *
+ */
 export const METAFILE_EXTNAME = '.META';

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -3,7 +3,7 @@ export interface UploadList {
   items: {
     /** upload name */
     name: string;
-    updated?: Date | number | string;
+    created: Date;
   }[];
 }
 

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -46,12 +46,13 @@ export class MetaStorage<T> {
 
   /**
    * Retrieves a list of uploads whose names begin with the prefix
+   * @experimental
    */
   async list(prefix = ''): Promise<UploadList> {
     return { items: [] };
   }
 }
 /**
- *
+ * @deprecated
  */
 export const METAFILE_EXTNAME = '.META';

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -1,6 +1,8 @@
-export interface ListObject {
-  name: string;
-  updated?: Date | number | string;
+export interface UploadList {
+  items: {
+    name: string;
+    updated?: Date | number | string;
+  }[];
 }
 export interface MetaStorageOptions {
   prefix?: string;
@@ -26,8 +28,8 @@ export class MetaStorage<T> {
     return Promise.reject();
   }
 
-  async list(prefix: string): Promise<ListObject[]> {
-    return Promise.reject();
+  async list(prefix: string): Promise<UploadList> {
+    return { items: [] };
   }
 }
 

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -1,5 +1,7 @@
+/** @experimental */
 export interface UploadList {
   items: {
+    /** upload name */
     name: string;
     updated?: Date | number | string;
   }[];
@@ -9,13 +11,14 @@ export interface MetaStorageOptions {
   prefix?: string;
   suffix?: string;
 }
+
 /**
  * Stores upload metadata
  */
 export class MetaStorage<T> {
   prefix = '';
   suffix = METAFILE_EXTNAME;
-  constructor(readonly config?: MetaStorageOptions) {
+  constructor(config?: MetaStorageOptions) {
     this.prefix = config?.prefix ?? '';
     this.suffix = config?.suffix ?? METAFILE_EXTNAME;
   }

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -13,8 +13,8 @@ import {
   Validator,
   ValidatorConfig
 } from '../utils';
-import { File, FileInit, FilePart } from './file';
-import { UploadList, METAFILE_EXTNAME, MetaStorage } from './meta-storage';
+import { File, FileInit, FilePart, updateMetadata } from './file';
+import { METAFILE_EXTNAME, MetaStorage, UploadList } from './meta-storage';
 
 export type OnComplete<TFile extends File, TResponseBody = any> = (
   file: TFile
@@ -156,6 +156,17 @@ export abstract class BaseStorage<TFile extends File> {
   }
 
   /**
+   * Update user-provided metadata
+   * @todo Metadata size limit
+   */
+  async update(name: string, { metadata }: Partial<File>): Promise<TFile> {
+    const file = await this.getMeta(name);
+    updateMetadata(file, metadata);
+    await this.saveMeta(file);
+    return { ...file, status: 'updated' };
+  }
+
+  /**
    * Add an upload to storage
    */
   abstract create(req: http.IncomingMessage, file: FileInit): Promise<TFile>;
@@ -169,9 +180,4 @@ export abstract class BaseStorage<TFile extends File> {
    * Delete files whose path starts with the specified prefix
    */
   abstract delete(prefix: string): Promise<TFile[]>;
-
-  /**
-   * Update upload metadata
-   */
-  abstract update(name: string, file: Partial<File>): Promise<TFile>;
 }

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -14,7 +14,7 @@ import {
   ValidatorConfig
 } from '../utils';
 import { File, FileInit, FilePart } from './file';
-import { METAFILE_EXTNAME, MetaStorage, MetaStorageOptions } from './meta-storage';
+import { UploadList, METAFILE_EXTNAME, MetaStorage, MetaStorageOptions } from './meta-storage';
 
 export type OnComplete<TFile extends File, TResponseBody = any> = (
   file: TFile
@@ -52,7 +52,7 @@ const defaultOptions = {
   maxMetadataSize: '4MB'
 };
 
-export abstract class BaseStorage<TFile extends File, TList> {
+export abstract class BaseStorage<TFile extends File> {
   static maxCacheMemory = '800MB';
   maxFilenameLength = 255 - METAFILE_EXTNAME.length;
   onComplete: (file: TFile) => Promise<any> | any;
@@ -138,6 +138,10 @@ export abstract class BaseStorage<TFile extends File, TList> {
     return fail(ERRORS.FILE_NOT_FOUND);
   }
 
+  async get(prefix = ''): Promise<UploadList> {
+    return this.meta.list(prefix);
+  }
+
   /**
    * Add an upload to storage
    */
@@ -153,12 +157,6 @@ export abstract class BaseStorage<TFile extends File, TList> {
    * @param prefix
    */
   abstract delete(prefix: string): Promise<TFile[]>;
-
-  /**
-   * Returns files whose path starts with the specified prefix
-   * @param prefix If not specified returns all files
-   */
-  abstract get(prefix?: string): Promise<TList[]>;
 
   /**
    * Update upload metadata

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -115,19 +115,26 @@ export abstract class BaseStorage<TFile extends File> {
     };
   }
 
-  async saveMetaFile(file: TFile): Promise<TFile> {
+  /**
+   * Save upload metadata
+   */
+  async saveMeta(file: TFile): Promise<TFile> {
     this.cache.set(file.name, file);
-    await this.meta.set(file.name, file);
-    return file;
+    return this.meta.save(file.name, file);
   }
 
-  async deleteMetaFile(name: string): Promise<void> {
+  /**
+   * Deletes an upload metadata
+   */
+  async deleteMeta(name: string): Promise<void> {
     this.cache.delete(name);
-    await this.meta.remove(name);
-    return;
+    return this.meta.delete(name);
   }
 
-  async getMetaFile(name: string): Promise<TFile> {
+  /**
+   * Retrieves upload metadata
+   */
+  async getMeta(name: string): Promise<TFile> {
     let file = this.cache.get(name);
     if (file) return file;
     try {
@@ -139,6 +146,13 @@ export abstract class BaseStorage<TFile extends File> {
   }
 
   async get(prefix = ''): Promise<UploadList> {
+    return this.meta.list(prefix);
+  }
+
+  /**
+   * Retrieves a list of uploads whose names begin with the prefix
+   */
+  async list(prefix = ''): Promise<UploadList> {
     return this.meta.list(prefix);
   }
 

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -14,7 +14,7 @@ import {
   ValidatorConfig
 } from '../utils';
 import { File, FileInit, FilePart } from './file';
-import { UploadList, METAFILE_EXTNAME, MetaStorage, MetaStorageOptions } from './meta-storage';
+import { UploadList, METAFILE_EXTNAME, MetaStorage } from './meta-storage';
 
 export type OnComplete<TFile extends File, TResponseBody = any> = (
   file: TFile
@@ -34,11 +34,10 @@ export interface BaseStorageOptions<T extends File> {
   path?: string;
   /** Upload validation options */
   validation?: Validation<T>;
-  /** Metadata size limit */
+  /** Limiting the size of custom metadata */
   maxMetadataSize?: number | string;
+  /** Provide custom meta storage  */
   metaStorage?: MetaStorage<T>;
-  metaStoragePath?: string;
-  metaStorageConfig?: MetaStorageOptions;
 }
 
 const defaultOptions = {
@@ -116,7 +115,7 @@ export abstract class BaseStorage<TFile extends File> {
   }
 
   /**
-   * Save upload metadata
+   * Saves upload metadata
    */
   async saveMeta(file: TFile): Promise<TFile> {
     this.cache.set(file.name, file);
@@ -168,7 +167,6 @@ export abstract class BaseStorage<TFile extends File> {
 
   /**
    * Delete files whose path starts with the specified prefix
-   * @param prefix
    */
   abstract delete(prefix: string): Promise<TFile[]>;
 

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -150,6 +150,7 @@ export abstract class BaseStorage<TFile extends File> {
 
   /**
    * Retrieves a list of uploads whose names begin with the prefix
+   * @experimental
    */
   async list(prefix = ''): Promise<UploadList> {
     return this.meta.list(prefix);
@@ -157,6 +158,7 @@ export abstract class BaseStorage<TFile extends File> {
 
   /**
    * Update user-provided metadata
+   * @experimental
    * @todo Metadata size limit
    */
   async update(name: string, { metadata }: Partial<File>): Promise<TFile> {

--- a/packages/gcs/src/constants.ts
+++ b/packages/gcs/src/constants.ts
@@ -1,0 +1,4 @@
+export const BUCKET_NAME = 'node-uploadx';
+export const uploadAPI = `https://storage.googleapis.com/upload/storage/v1/b`;
+export const storageAPI = `https://storage.googleapis.com/storage/v1/b`;
+export const authScopes = ['https://www.googleapis.com/auth/devstorage.full_control'];

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -67,12 +67,15 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
     const url = '/';
     const options = { baseURL, url, params: { prefix: encodeURIComponent(prefix) } };
     const { data } = await this.authClient.request<{
-      items: { name: string; updated: Date; metadata: T }[];
+      items: { name: string; timeCreated: string; metadata?: T }[];
     }>(options);
     return {
       items: data.items
         .filter(item => item.name.endsWith(this.suffix))
-        .map(({ name, updated }) => ({ name: this.getNameFromPath(name), updated }))
+        .map(({ name, timeCreated }) => ({
+          name: this.getNameFromPath(name),
+          created: new Date(timeCreated)
+        }))
     };
   }
 }

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -1,0 +1,73 @@
+import { File, ListObject, MetaStorage } from '@uploadx/core';
+import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
+import { authScopes, BUCKET_NAME, storageAPI, uploadAPI } from './constants';
+
+export type GCSMetaStorageOptions = GoogleAuthOptions & {
+  bucket?: string;
+  prefix?: string;
+  suffix?: string;
+};
+
+export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
+  authClient: GoogleAuth;
+  storageBaseURI: string;
+  uploadBaseURI: string;
+
+  constructor(readonly config: GCSMetaStorageOptions = {}) {
+    super();
+    config.scopes ||= authScopes;
+    config.keyFile ||= process.env.GCS_KEYFILE;
+    const bucketName = config.bucket || process.env.GCS_BUCKET || BUCKET_NAME;
+    this.storageBaseURI = [storageAPI, bucketName, 'o'].join('/');
+    this.authClient = new GoogleAuth(config);
+    this.uploadBaseURI = [uploadAPI, bucketName, 'o'].join('/');
+  }
+
+  getMetaName = (name: string): string => this.prefix + name + this.suffix;
+
+  getMetaPath(name: string): string {
+    return `${this.storageBaseURI}/${this.getMetaName(name)}`;
+  }
+
+  getNameFromPath = (metaFilePath: string): string =>
+    metaFilePath.slice(`${this.prefix}`.length, -this.suffix.length);
+
+  async set(name: string, file: T): Promise<T> {
+    //TODO: use JSON API multipart POST?
+    await this.authClient.request({
+      body: JSON.stringify(file),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      method: 'POST',
+      params: { name: encodeURIComponent(this.getMetaName(name)), uploadType: 'media' },
+      url: this.uploadBaseURI
+    });
+    return file;
+  }
+
+  async remove(name: string): Promise<void> {
+    const url = this.getMetaPath(name);
+    await this.authClient.request({ method: 'DELETE', url });
+    return;
+  }
+
+  async get(name: string): Promise<T> {
+    const url = this.getMetaPath(name);
+    const { data } = await this.authClient.request<T>({ params: { alt: 'media' }, url });
+    return data;
+  }
+
+  async list(prefix: string): Promise<ListObject[]> {
+    const baseURL = this.storageBaseURI;
+    const url = '/';
+    const options = { baseURL, url, params: { prefix: encodeURIComponent(prefix) } };
+    const { data } = await this.authClient.request<{
+      items: { name: string; updated: Date; metadata: T }[];
+    }>(options);
+    return (
+      data.items
+        .filter(item => item.name.endsWith(this.suffix))
+        //.map(({ name, metadata = {} as T, updated }) => ({ ...metadata, name, updated }));
+        .map(({ name, updated }) => ({ name: this.getNameFromPath(name), updated }))
+    );
+  }
+}

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -1,4 +1,4 @@
-import { File, ListObject, MetaStorage } from '@uploadx/core';
+import { File, UploadList, MetaStorage } from '@uploadx/core';
 import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
 import { authScopes, BUCKET_NAME, storageAPI, uploadAPI } from './constants';
 
@@ -56,18 +56,17 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
     return data;
   }
 
-  async list(prefix: string): Promise<ListObject[]> {
+  async list(prefix: string): Promise<UploadList> {
     const baseURL = this.storageBaseURI;
     const url = '/';
     const options = { baseURL, url, params: { prefix: encodeURIComponent(prefix) } };
     const { data } = await this.authClient.request<{
       items: { name: string; updated: Date; metadata: T }[];
     }>(options);
-    return (
-      data.items
+    return {
+      items: data.items
         .filter(item => item.name.endsWith(this.suffix))
-        //.map(({ name, metadata = {} as T, updated }) => ({ ...metadata, name, updated }));
         .map(({ name, updated }) => ({ name: this.getNameFromPath(name), updated }))
-    );
+    };
   }
 }

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -12,7 +12,7 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
   uploadBaseURI: string;
 
   constructor(readonly config: GCSMetaStorageOptions = {}) {
-    super();
+    super(config);
     config.scopes ||= authScopes;
     config.keyFile ||= process.env.GCS_KEYFILE;
     const bucketName = config.bucket || process.env.GCS_BUCKET || BUCKET_NAME;

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -1,12 +1,10 @@
-import { File, UploadList, MetaStorage } from '@uploadx/core';
+import { File, UploadList, MetaStorage, MetaStorageOptions } from '@uploadx/core';
 import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
 import { authScopes, BUCKET_NAME, storageAPI, uploadAPI } from './constants';
 
-export type GCSMetaStorageOptions = GoogleAuthOptions & {
+export interface GCSMetaStorageOptions extends GoogleAuthOptions, MetaStorageOptions {
   bucket?: string;
-  prefix?: string;
-  suffix?: string;
-};
+}
 
 export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
   authClient: GoogleAuth;

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -25,14 +25,22 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
 
   getMetaName = (name: string): string => this.prefix + name + this.suffix;
 
+  /**
+   * Returns metafile url
+   * @param name upload name
+   */
   getMetaPath(name: string): string {
     return `${this.storageBaseURI}/${this.getMetaName(name)}`;
   }
 
+  /**
+   * Returns upload name from metafile url
+   * @internal
+   */
   getNameFromPath = (metaFilePath: string): string =>
     metaFilePath.slice(`${this.prefix}`.length, -this.suffix.length);
 
-  async set(name: string, file: T): Promise<T> {
+  async save(name: string, file: T): Promise<T> {
     //TODO: use JSON API multipart POST?
     await this.authClient.request({
       body: JSON.stringify(file),
@@ -44,7 +52,7 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
     return file;
   }
 
-  async remove(name: string): Promise<void> {
+  async delete(name: string): Promise<void> {
     const url = this.getMetaPath(name);
     await this.authClient.request({ method: 'DELETE', url });
     return;

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -13,8 +13,7 @@ import {
   isValidPart,
   LocalMetaStorage,
   LocalMetaStorageOptions,
-  MetaStorage,
-  updateMetadata
+  MetaStorage
 } from '@uploadx/core';
 import { AbortController } from 'abort-controller';
 import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
@@ -163,13 +162,6 @@ export class GCStorage extends BaseStorage<GCSFile> {
       return [{ ...file }];
     }
     return [{ name } as GCSFile];
-  }
-
-  async update(name: string, { metadata }: Partial<File>): Promise<GCSFile> {
-    const file = await this.getMeta(name);
-    updateMetadata(file, metadata);
-    await this.saveMeta(file);
-    return { ...file, status: 'updated' };
   }
 
   protected async _write(part: FilePart & GCSFile): Promise<number> {

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -54,6 +54,21 @@ export interface GCStorageOptions extends BaseStorageOptions<GCSFile>, GoogleAut
    * Force compatible client upload directly to GCS
    */
   clientDirectUpload?: boolean;
+  /**
+   * Configure metafiles storage
+   * @example
+   * // use local metafiles
+   * const storage = new GCStorage({
+   *   bucket: 'uploads',
+   *   metaStorageConfig: { directory: '/tmp/upload-metafiles' }
+   * })
+   * @example
+   * // use a separate bucket for metafiles
+   * const storage = new GCStorage({
+   *   bucket: 'uploads',
+   *   metaStorageConfig: { bucket: 'upload-metafiles' }
+   * })
+   */
   metaStorageConfig?: LocalMetaStorageOptions | GCSMetaStorageOptions;
 }
 

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -79,6 +79,16 @@ export class GCSFile extends File {
 
 /**
  * Google cloud storage based backend.
+ * @example
+    const storage = new GCStorage({
+      bucket: <YOUR_BUCKET>,
+      keyFile: <PATH_TO_KEY_FILE>,
+      metaStorage: new MetaStorage(),
+      clientDirectUpload: true,
+      maxUploadSize: '15GB',
+      allowMIME: ['video/*', 'image/*'],
+      filename: file => file.originalName
+    });
  */
 export class GCStorage extends BaseStorage<GCSFile> {
   authClient: GoogleAuth;

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -11,7 +11,6 @@ import {
   HttpError,
   isCompleted,
   isValidPart,
-  ListObject,
   LocalMetaStorage,
   MetaStorage,
   updateMetadata
@@ -63,12 +62,10 @@ export class GCSFile extends File {
   uri = '';
 }
 
-type CGSListObject = ListObject;
-
 /**
  * Google cloud storage based backend.
  */
-export class GCStorage extends BaseStorage<GCSFile, CGSListObject> {
+export class GCStorage extends BaseStorage<GCSFile> {
   authClient: GoogleAuth;
   storageBaseURI: string;
   uploadBaseURI: string;
@@ -164,10 +161,6 @@ export class GCStorage extends BaseStorage<GCSFile, CGSListObject> {
       return [{ ...file }];
     }
     return [{ name } as GCSFile];
-  }
-
-  async get(prefix = ''): Promise<CGSListObject[]> {
-    return this.meta.list(prefix);
   }
 
   async update(name: string, { metadata }: Partial<File>): Promise<GCSFile> {

--- a/packages/gcs/src/index.ts
+++ b/packages/gcs/src/index.ts
@@ -1,1 +1,2 @@
 export * from './gcs-storage';
+export * from './constants';

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -1,13 +1,11 @@
-import { File, UploadList, MetaStorage } from '@uploadx/core';
+import { File, UploadList, MetaStorage, MetaStorageOptions } from '@uploadx/core';
 import { config as AWSConfig, S3 } from 'aws-sdk';
 
 const BUCKET_NAME = 'node-uploadx';
-export type S3MetaStorageOptions = S3.ClientConfiguration & {
+export interface S3MetaStorageOptions extends S3.ClientConfiguration, MetaStorageOptions {
   bucket?: string;
   keyFile?: string;
-  prefix?: string;
-  suffix?: string;
-};
+}
 
 export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
   bucket: string;

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -1,0 +1,72 @@
+import { File, ListObject, MetaStorage } from '@uploadx/core';
+import { config as AWSConfig, S3 } from 'aws-sdk';
+
+const BUCKET_NAME = 'node-uploadx';
+export type S3MetaStorageOptions = S3.ClientConfiguration & {
+  bucket?: string;
+  keyFile?: string;
+  prefix?: string;
+  suffix?: string;
+};
+
+export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
+  bucket: string;
+  client: S3;
+
+  constructor(readonly config: S3MetaStorageOptions) {
+    super(config);
+    this.bucket = config.bucket || process.env.S3_BUCKET || BUCKET_NAME;
+    const keyFile = config.keyFile || process.env.S3_KEYFILE;
+    keyFile && AWSConfig.loadFromPath(keyFile);
+    this.client = new S3(config);
+    this.prefix = config?.prefix ?? '';
+  }
+
+  getMetaName(name: string): string {
+    return this.prefix + name + this.suffix;
+  }
+
+  async get(name: string): Promise<T> {
+    const params = { Bucket: this.bucket, Key: this.getMetaName(name) };
+    const { Metadata } = await this.client.headObject(params).promise();
+    if (Metadata) {
+      return JSON.parse(decodeURIComponent(Metadata.metadata)) as T;
+    }
+    return Promise.reject();
+  }
+
+  async remove(name: string): Promise<void> {
+    const params = { Bucket: this.bucket, Key: this.getMetaName(name) };
+    await this.client
+      .deleteObject(params)
+      .promise()
+      .catch(() => null);
+  }
+
+  async set(name: string, file: T): Promise<T> {
+    const metadata = encodeURIComponent(JSON.stringify(file));
+    const params = {
+      Bucket: this.bucket,
+      Key: this.getMetaName(name),
+      Metadata: { metadata }
+    };
+    await this.client.putObject(params).promise();
+    return file;
+  }
+
+  async list(prefix: string): Promise<ListObject[]> {
+    const params: S3.ListObjectsV2Request = {
+      Bucket: this.bucket,
+      Prefix: prefix,
+      Delimiter: this.suffix
+    };
+    const response = await this.client.listObjectsV2(params).promise();
+    if (response.Contents?.length) {
+      return response.Contents.map(({ Key, LastModified }) => ({
+        name: Key?.slice(this.prefix.length, -this.suffix.length) || '',
+        updated: LastModified
+      }));
+    }
+    return [];
+  }
+}

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -35,7 +35,7 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
     return Promise.reject();
   }
 
-  async remove(name: string): Promise<void> {
+  async delete(name: string): Promise<void> {
     const params = { Bucket: this.bucket, Key: this.getMetaName(name) };
     await this.client
       .deleteObject(params)
@@ -43,7 +43,7 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
       .catch(() => null);
   }
 
-  async set(name: string, file: T): Promise<T> {
+  async save(name: string, file: T): Promise<T> {
     const metadata = encodeURIComponent(JSON.stringify(file));
     const params = {
       Bucket: this.bucket,

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -55,18 +55,22 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
   async list(prefix: string): Promise<UploadList> {
     const params: S3.ListObjectsV2Request = {
       Bucket: this.bucket,
-      Prefix: prefix,
-      Delimiter: this.suffix
+      Prefix: prefix
+      // Delimiter: this.suffix
     };
+    const items = [];
     const response = await this.client.listObjectsV2(params).promise();
     if (response.Contents?.length) {
-      return {
-        items: response.Contents.map(({ Key, LastModified }) => ({
-          name: Key?.slice(this.prefix.length, -this.suffix.length) || '',
-          updated: LastModified
-        }))
-      };
+      for (const { Key, LastModified } of response.Contents) {
+        Key &&
+          LastModified &&
+          Key.endsWith(this.suffix) &&
+          items.push({
+            name: Key?.slice(this.prefix.length, -this.suffix.length),
+            created: LastModified
+          });
+      }
     }
-    return { items: [] };
+    return { items };
   }
 }

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -1,4 +1,4 @@
-import { File, ListObject, MetaStorage } from '@uploadx/core';
+import { File, UploadList, MetaStorage } from '@uploadx/core';
 import { config as AWSConfig, S3 } from 'aws-sdk';
 
 const BUCKET_NAME = 'node-uploadx';
@@ -54,7 +54,7 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
     return file;
   }
 
-  async list(prefix: string): Promise<ListObject[]> {
+  async list(prefix: string): Promise<UploadList> {
     const params: S3.ListObjectsV2Request = {
       Bucket: this.bucket,
       Prefix: prefix,
@@ -62,11 +62,13 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
     };
     const response = await this.client.listObjectsV2(params).promise();
     if (response.Contents?.length) {
-      return response.Contents.map(({ Key, LastModified }) => ({
-        name: Key?.slice(this.prefix.length, -this.suffix.length) || '',
-        updated: LastModified
-      }));
+      return {
+        items: response.Contents.map(({ Key, LastModified }) => ({
+          name: Key?.slice(this.prefix.length, -this.suffix.length) || '',
+          updated: LastModified
+        }))
+      };
     }
-    return [];
+    return { items: [] };
   }
 }

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -17,7 +17,6 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
     const keyFile = config.keyFile || process.env.S3_KEYFILE;
     keyFile && AWSConfig.loadFromPath(keyFile);
     this.client = new S3(config);
-    this.prefix = config?.prefix ?? '';
   }
 
   getMetaName(name: string): string {

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -32,10 +32,13 @@ export class S3File extends File {
 export type S3StorageOptions = BaseStorageOptions<S3File> &
   S3.ClientConfiguration & {
     /**
-     * AWS S3 bucket
+     * S3 bucket
      * @defaultValue 'node-uploadx'
      */
     bucket?: string;
+    /**
+     * Load configuration and credentials from the specified file
+     */
     keyFile?: string;
     /**
      * Configure metafiles storage
@@ -55,6 +58,20 @@ export type S3StorageOptions = BaseStorageOptions<S3File> &
     metaStorageConfig?: LocalMetaStorageOptions | S3MetaStorageOptions;
   };
 
+/**
+ * S3 storage based backend.
+ * @example
+   const storage = new S3Storage({
+    bucket: <YOUR_BUCKET>,
+    endpoint: <YOUR_ENDPOINT>,
+    region: <YOUR_REGION>,
+    credentials: {
+      accessKeyId: <YOUR_ACCESS_KEY_ID>,
+      secretAccessKey: <YOUR_SECRET_ACCESS_KEY>
+    },
+    metaStorageConfig: { directory: '/tmp/upload-metafiles' }
+  });
+ */
 export class S3Storage extends BaseStorage<S3File> {
   bucket: string;
   client: S3;

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -37,6 +37,21 @@ export type S3StorageOptions = BaseStorageOptions<S3File> &
      */
     bucket?: string;
     keyFile?: string;
+    /**
+     * Configure metafiles storage
+     * @example
+     * // use local metafiles
+     * const storage = new S3Storage({
+     *   bucket: 'uploads',
+     *   metaStorageConfig: { directory: '/tmp/upload-metafiles' }
+     * })
+     * @example
+     * // use a separate bucket for metafiles
+     * const storage = new S3Storage({
+     *   bucket: 'uploads',
+     *   metaStorageConfig: { bucket: 'upload-metafiles' }
+     * })
+     */
     metaStorageConfig?: LocalMetaStorageOptions | S3MetaStorageOptions;
   };
 

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -15,8 +15,7 @@ import {
   LocalMetaStorage,
   LocalMetaStorageOptions,
   mapValues,
-  MetaStorage,
-  updateMetadata
+  MetaStorage
 } from '@uploadx/core';
 import { AWSError, config as AWSConfig, S3 } from 'aws-sdk';
 import * as http from 'http';
@@ -147,13 +146,6 @@ export class S3Storage extends BaseStorage<S3File> {
       return [{ ...file }];
     }
     return [{ name } as S3File];
-  }
-
-  async update(name: string, { metadata }: Partial<File>): Promise<S3File> {
-    const file = await this.getMeta(name);
-    updateMetadata(file, metadata);
-    await this.saveMeta(file);
-    return { ...file, status: 'updated' };
   }
 
   protected _onComplete = (file: S3File): Promise<[S3.CompleteMultipartUploadOutput, any]> => {

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+
 import {
   BaseStorage,
   BaseStorageOptions,
@@ -9,14 +10,16 @@ import {
   FilePart,
   hasContent,
   HttpError,
+  isCompleted,
   isValidPart,
+  LocalMetaStorage,
   mapValues,
-  METAFILE_EXTNAME,
-  updateMetadata,
-  isCompleted
+  MetaStorage,
+  updateMetadata
 } from '@uploadx/core';
 import { AWSError, config as AWSConfig, S3 } from 'aws-sdk';
 import * as http from 'http';
+import { S3MetaStorage } from './s3-meta-storage';
 
 const BUCKET_NAME = 'node-uploadx';
 
@@ -38,13 +41,13 @@ export type S3StorageOptions = BaseStorageOptions<S3File> &
 
 export interface S3ListObject {
   name?: string;
-
   updated?: any;
 }
 
-export class S3Storage extends BaseStorage<S3File, any> {
+export class S3Storage extends BaseStorage<S3File, S3ListObject> {
   bucket: string;
   client: S3;
+  meta: MetaStorage<S3File>;
 
   constructor(public config: S3StorageOptions) {
     super(config);
@@ -52,6 +55,12 @@ export class S3Storage extends BaseStorage<S3File, any> {
     const keyFile = config.keyFile || process.env.S3_KEYFILE;
     keyFile && AWSConfig.loadFromPath(keyFile);
     this.client = new S3(config);
+    this.meta = config.metaStorage
+      ? config.metaStorage
+      : (this.meta =
+          typeof config.metaStoragePath === 'string'
+            ? new LocalMetaStorage({ directory: config.metaStoragePath })
+            : new S3MetaStorage(config));
     this._checkBucket();
   }
 
@@ -73,7 +82,7 @@ export class S3Storage extends BaseStorage<S3File, any> {
     file.name = this.namingFunction(file);
     await this.validate(file);
     try {
-      const existing = await this._getMeta(file.name);
+      const existing = await this.getMetaFile(file.name);
       if (existing.bytesWritten >= 0) {
         return existing;
       }
@@ -92,16 +101,21 @@ export class S3Storage extends BaseStorage<S3File, any> {
     }
     file.UploadId = UploadId;
     file.bytesWritten = 0;
-    await this._saveMeta(file);
+    await this.saveMetaFile(file);
     file.status = 'created';
     return file;
   }
 
   async write(part: FilePart): Promise<S3File> {
-    const file = await this._getMeta(part.name);
+    const file = await this.getMetaFile(part.name);
     if (file.status === 'completed') return file;
     if (!isValidPart(part, file)) return fail(ERRORS.FILE_CONFLICT);
-    file.Parts ||= [];
+    file.Parts ||= await this._getParts(file);
+    file.bytesWritten = file.Parts.map(item => item.Size || 0).reduce(
+      (prev, next) => prev + next,
+      0
+    );
+    this.cache.set(file.name, file);
     if (hasContent(part)) {
       const partNumber = file.Parts.length + 1;
       const params: S3.UploadPartRequest = {
@@ -126,80 +140,34 @@ export class S3Storage extends BaseStorage<S3File, any> {
   }
 
   async delete(name: string): Promise<S3File[]> {
-    const file = await this._getMeta(name).catch(() => null);
+    const file = await this.getMetaFile(name).catch(() => null);
     if (file) {
       file.status = 'deleted';
-      await Promise.all([this._deleteMeta(file.name), this._abortMultipartUpload(file)]);
+      await Promise.all([this.deleteMetaFile(file.name), this._abortMultipartUpload(file)]);
       return [{ ...file }];
     }
     return [{ name } as S3File];
   }
 
   async get(prefix = ''): Promise<S3ListObject[]> {
-    const re = new RegExp(`${METAFILE_EXTNAME}$`);
-    const params = { Bucket: this.bucket, Prefix: prefix };
-    const { Contents } = await this.client.listObjectsV2(params).promise();
-    if (Contents?.length) {
-      return Contents.filter(item => item.Key?.endsWith(METAFILE_EXTNAME)).map(
-        ({ Key, LastModified }) => ({ name: Key?.replace(re, ''), updated: LastModified })
-      );
-    }
-    return [];
+    return this.meta.list(prefix);
   }
 
   async update(name: string, { metadata }: Partial<File>): Promise<S3File> {
-    const file = await this._getMeta(name);
+    const file = await this.getMetaFile(name);
     updateMetadata(file, metadata);
-    await this._saveMeta(file);
+    await this.saveMetaFile(file);
     return { ...file, status: 'updated' };
   }
 
-  protected async _saveMeta(file: S3File): Promise<any> {
-    const metadata = encodeURIComponent(JSON.stringify(file));
-    const params = {
-      Bucket: this.bucket,
-      Key: file.name + METAFILE_EXTNAME,
-      Metadata: { metadata }
-    };
-    await this.client.putObject(params).promise();
-    this.cache.set(file.name, file);
-  }
-
-  protected async _getMeta(name: string): Promise<S3File> {
-    let file = this.cache.get(name);
-    if (file) return file;
-    try {
-      const params = { Bucket: this.bucket, Key: name + METAFILE_EXTNAME };
-      const { Metadata } = await this.client.headObject(params).promise();
-      if (Metadata) {
-        const data: S3File = JSON.parse(decodeURIComponent(Metadata.metadata)) as S3File;
-        const uploaded = await this._getParts(data);
-        file = { ...data, ...uploaded };
-        this.cache.set(name, file);
-        return file;
-      }
-    } catch {}
-    return fail(ERRORS.FILE_NOT_FOUND);
-  }
-
-  protected async _deleteMeta(name: string): Promise<void> {
-    this.cache.delete(name);
-    const params = { Bucket: this.bucket, Key: name + METAFILE_EXTNAME };
-    await this.client
-      .deleteObject(params)
-      .promise()
-      .catch(() => null);
-  }
-
   protected _onComplete = (file: S3File): Promise<[S3.CompleteMultipartUploadOutput, any]> => {
-    return Promise.all([this._complete(file), this._deleteMeta(file.name)]);
+    return Promise.all([this._complete(file), this.deleteMetaFile(file.name)]);
   };
 
-  private async _getParts(file: S3File): Promise<{ bytesWritten: number; Parts: S3.Parts }> {
+  private async _getParts(file: S3File): Promise<S3.Parts> {
     const params = { Bucket: this.bucket, Key: file.name, UploadId: file.UploadId };
     const { Parts = [] } = await this.client.listParts(params).promise();
-    const bytesWritten = Parts.map(item => item.Size || 0).reduce((prev, next) => prev + next, 0);
-    return { bytesWritten, Parts };
+    return Parts;
   }
 
   private _complete(file: S3File): Promise<S3.CompleteMultipartUploadOutput> {
@@ -215,6 +183,7 @@ export class S3Storage extends BaseStorage<S3File, any> {
   }
 
   private async _abortMultipartUpload(file: S3File): Promise<any> {
+    if (file.status === 'completed') return;
     try {
       const params = { Bucket: this.bucket, Key: file.name, UploadId: file.UploadId };
       await this.client.abortMultipartUpload(params).promise();

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -39,12 +39,7 @@ export type S3StorageOptions = BaseStorageOptions<S3File> &
     keyFile?: string;
   };
 
-export interface S3ListObject {
-  name?: string;
-  updated?: any;
-}
-
-export class S3Storage extends BaseStorage<S3File, S3ListObject> {
+export class S3Storage extends BaseStorage<S3File> {
   bucket: string;
   client: S3;
   meta: MetaStorage<S3File>;
@@ -147,10 +142,6 @@ export class S3Storage extends BaseStorage<S3File, S3ListObject> {
       return [{ ...file }];
     }
     return [{ name } as S3File];
-  }
-
-  async get(prefix = ''): Promise<S3ListObject[]> {
-    return this.meta.list(prefix);
   }
 
   async update(name: string, { metadata }: Partial<File>): Promise<S3File> {

--- a/test/disk-storage.spec.ts
+++ b/test/disk-storage.spec.ts
@@ -125,15 +125,15 @@ describe('DiskStorage', () => {
     beforeEach(createFile);
 
     it('should return all user files', async () => {
-      const files = await storage.get(testfile.userId);
-      expect(files).toHaveLength(1);
-      expect(files[0]).toMatchObject({ name: filename });
+      const { items } = await storage.get(testfile.userId);
+      expect(items).toHaveLength(1);
+      expect(items[0]).toMatchObject({ name: filename });
     });
 
     it('should return one file', async () => {
-      const files = await storage.get(filename);
-      expect(files).toHaveLength(1);
-      expect(files[0]).toMatchObject({ name: filename });
+      const { items } = await storage.get(filename);
+      expect(items).toHaveLength(1);
+      expect(items[0]).toMatchObject({ name: filename });
     });
   });
 

--- a/test/disk-storage.spec.ts
+++ b/test/disk-storage.spec.ts
@@ -7,7 +7,6 @@ import { filename, metafile, testfile } from './fixtures/testfile';
 const directory = 'ds-test';
 let writeStream: FileWriteStream;
 
-jest.mock('../packages/core/src/utils/cache');
 jest.mock('../packages/core/src/utils/fs', () => {
   return {
     ensureFile: async () => 0,
@@ -45,6 +44,8 @@ describe('DiskStorage', () => {
   });
 
   describe('.create()', () => {
+    beforeEach(() => (storage = new DiskStorage(options)));
+
     it('should set status', async () => {
       const { status, bytesWritten } = await storage.create({} as any, testfile);
       expect(bytesWritten).toBe(0);
@@ -72,11 +73,10 @@ describe('DiskStorage', () => {
   });
 
   describe('.write()', () => {
-    beforeEach(createFile);
-
     beforeEach(() => {
       writeStream = new FileWriteStream();
       mockReadable = new RequestReadStream();
+      return createFile();
     });
 
     it('should set status and bytesWritten', async () => {
@@ -93,6 +93,7 @@ describe('DiskStorage', () => {
     });
 
     it('should reject with 404', async () => {
+      storage.cache.delete(testfile.name);
       const mockReadFile = jest.spyOn(fsp, 'readFile');
       mockReadFile.mockRejectedValueOnce(new Error('not found'));
       const write = storage.write({ ...testfile });

--- a/test/fixtures/uploader.ts
+++ b/test/fixtures/uploader.ts
@@ -8,9 +8,9 @@ import {
   MetaStorage
 } from '../../packages/core/src';
 
-export class TestUploader extends BaseHandler<File, File[]> {}
+export class TestUploader extends BaseHandler<File> {}
 
-class TestStorage extends BaseStorage<File, any> {
+class TestStorage extends BaseStorage<File> {
   meta = new MetaStorage<File>();
   path = '/files';
   isReady = true;
@@ -35,7 +35,7 @@ class TestStorage extends BaseStorage<File, any> {
     throw new Error('Method not implemented.');
   }
 
-  get = (_url: any): Promise<any> => Promise.resolve([]);
+  get = (_url: any): Promise<any> => Promise.resolve({ uploads: [] });
 }
 
 export const testStorage = new TestStorage();

--- a/test/fixtures/uploader.ts
+++ b/test/fixtures/uploader.ts
@@ -1,9 +1,17 @@
 import { IncomingMessage } from 'http';
-import { BaseHandler, BaseStorage, File, FileInit, FilePart } from '../../packages/core/src';
+import {
+  BaseHandler,
+  BaseStorage,
+  File,
+  FileInit,
+  FilePart,
+  MetaStorage
+} from '../../packages/core/src';
 
 export class TestUploader extends BaseHandler<File, File[]> {}
 
 class TestStorage extends BaseStorage<File, any> {
+  meta = new MetaStorage<File>();
   path = '/files';
   isReady = true;
 

--- a/test/gcs-storage.spec.ts
+++ b/test/gcs-storage.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { FilePart } from '@uploadx/core';
-import { buildContentRange, GCSFile, GCStorage, getRangeEnd } from '@uploadx/gcs';
+import { buildContentRange, GCSFile, GCStorage, GCStorageOptions, getRangeEnd } from '@uploadx/gcs';
 import { AbortSignal } from 'abort-controller';
 import { createReadStream } from 'fs';
 import { IncomingMessage } from 'http';
@@ -30,7 +30,7 @@ describe('GCStorage', () => {
 
   beforeEach(async () => {
     mockAuthRequest.mockResolvedValueOnce({ bucket: 'ok' });
-    storage = new GCStorage({ ...storageOptions });
+    storage = new GCStorage({ ...(storageOptions as GCStorageOptions) });
     file = _fileResponse().data;
   });
 

--- a/test/gcs-storage.spec.ts
+++ b/test/gcs-storage.spec.ts
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { FilePart } from '@uploadx/core';
-import { buildContentRange, GCSFile, GCStorage, GCStorageOptions, getRangeEnd } from '@uploadx/gcs';
+import { FilePart } from '../packages/core/src';
+import {
+  buildContentRange,
+  GCSFile,
+  GCStorage,
+  GCStorageOptions,
+  getRangeEnd
+} from '../packages/gcs/src';
 import { AbortSignal } from 'abort-controller';
 import { createReadStream } from 'fs';
 import { IncomingMessage } from 'http';
@@ -79,10 +85,10 @@ describe('GCStorage', () => {
         data: { items: [{ name: metafile }] }
       };
       mockAuthRequest.mockResolvedValue(list);
-      const files = await storage.get(testfile.userId);
-      expect(files).toEqual(expect.any(Array));
-      expect(files).toHaveLength(1);
-      expect(files[0]).toMatchObject({ name: filename });
+      const { items } = await storage.get(testfile.userId);
+      expect(items).toEqual(expect.any(Array));
+      expect(items).toHaveLength(1);
+      expect(items[0]).toMatchObject({ name: filename });
     });
   });
 

--- a/test/local-meta-storage.spec.ts
+++ b/test/local-meta-storage.spec.ts
@@ -1,0 +1,18 @@
+import { LocalMetaStorage } from '@uploadx/core';
+import * as path from 'path';
+
+describe('LocalMetaStorage', () => {
+  it('defaults', () => {
+    const meta = new LocalMetaStorage();
+    const metaPath = meta.getMetaPath('name.ext');
+    expect(path.basename(metaPath)).toBe('name.ext.META');
+    expect(meta.getNameFromPath(metaPath)).toBe('name.ext');
+  });
+
+  it('custom', () => {
+    const meta = new LocalMetaStorage({ prefix: '.', suffix: '.', directory: './meta' });
+    const metaPath = meta.getMetaPath('name.ext');
+    expect(metaPath).toBe('./meta/.name.ext.');
+    expect(meta.getNameFromPath(metaPath)).toBe('name.ext');
+  });
+});

--- a/test/s3-storage.spec.ts
+++ b/test/s3-storage.spec.ts
@@ -5,7 +5,7 @@ import { S3File, S3Storage } from '../packages/s3/src';
 import { FilePart } from '../packages/core/src';
 import { storageOptions } from './fixtures';
 import { filename, metafile, srcpath, testfile } from './fixtures/testfile';
-import { S3StorageOptions } from '@uploadx/s3';
+import { S3StorageOptions } from '../packages/s3/src';
 
 jest.mock('../packages/core/src/utils/cache');
 const mockHeadBucket = jest.fn();
@@ -134,10 +134,10 @@ describe('S3Storage', () => {
 
   describe('.get()', () => {
     it('should return all user files', async () => {
-      const files = await storage.get(testfile.userId);
-      expect(files).toEqual(expect.any(Array));
-      expect(files).toHaveLength(1);
-      expect(files[0]).toMatchObject({ name: filename });
+      const { items } = await storage.get(testfile.userId);
+      expect(items).toEqual(expect.any(Array));
+      expect(items).toHaveLength(1);
+      expect(items[0]).toMatchObject({ name: filename });
     });
   });
 

--- a/test/s3-storage.spec.ts
+++ b/test/s3-storage.spec.ts
@@ -5,6 +5,7 @@ import { S3File, S3Storage } from '../packages/s3/src';
 import { FilePart } from '../packages/core/src';
 import { storageOptions } from './fixtures';
 import { filename, metafile, srcpath, testfile } from './fixtures/testfile';
+import { S3StorageOptions } from '@uploadx/s3';
 
 jest.mock('../packages/core/src/utils/cache');
 const mockHeadBucket = jest.fn();
@@ -21,10 +22,7 @@ const mockPutObject = jest.fn(() => ({
 const mockListObjectsV2 = jest.fn(() => ({
   promise() {
     return Promise.resolve<S3.ListObjectsV2Output>({
-      Contents: [
-        { Key: 'already.uploaded', LastModified: new Date() },
-        { Key: metafile, LastModified: new Date() }
-      ]
+      Contents: [{ Key: metafile, LastModified: new Date() }]
     });
   }
 }));
@@ -81,7 +79,7 @@ jest.mock('aws-sdk', () => ({
 }));
 
 describe('S3Storage', () => {
-  const options = { ...storageOptions };
+  const options = { ...(storageOptions as S3StorageOptions) };
   testfile.name = filename;
 
   let file: S3File;

--- a/test/tus.spec.ts
+++ b/test/tus.spec.ts
@@ -25,7 +25,7 @@ describe('::Tus', () => {
     });
 
     it('custom storage', () => {
-      const storage = {} as BaseStorage<any, any>;
+      const storage = {} as BaseStorage<any>;
       expect(tus({ storage })).toBeInstanceOf(Function);
     });
   });

--- a/test/uploadx.spec.ts
+++ b/test/uploadx.spec.ts
@@ -2,7 +2,7 @@
 import * as fs from 'fs';
 import { join } from 'path';
 import * as request from 'supertest';
-import { uploadx } from '@uploadx/core';
+import { uploadx } from '../packages/core/src';
 import { root, storageOptions, userPrefix } from './fixtures';
 import { app } from './fixtures/app';
 import { metadata, srcpath } from './fixtures/testfile';
@@ -51,7 +51,7 @@ describe('::Uploadx', () => {
       await request(app).post(basePath).send('').expect(400);
     });
 
-    it('should  limit metadata size', async () => {
+    it('should limit metadata size', async () => {
       const res = await request(app)
         .post(basePath)
         .set('x-upload-content-type', 'video/mp4')
@@ -152,12 +152,12 @@ describe('::Uploadx', () => {
   describe('GET', () => {
     it('should return info array', async () => {
       const res = await request(app).get(`${basePath}/${userPrefix}`).expect(200);
-      expect(res.body).toHaveLength(2);
+      expect(res.body.items).toHaveLength(2);
     });
 
     it('should return info array(name)', async () => {
       const res = await request(app).get(`${basePath}?name=${userPrefix}`).expect(200);
-      expect(res.body).toHaveLength(2);
+      expect(res.body.items).toHaveLength(2);
     });
 
     it('should return 404(query)', async () => {


### PR DESCRIPTION
This PR adds:

- option for configuring metafile storage. Some examples:

  ```ts
  // use a custom path for metafiles
  const storage = new DiskStorage({
    directory: 'upload',
    metaStorageConfig: {
      directory: '/tmp/upload-metafiles',
      prefix: '.',
      suffix: '.json'
    }
  });
  ```

  ```ts
  // use local metafiles while uploading to cloud
  const storage = new GCStorage({
    bucket: 'uploads',
    metaStorageConfig: { directory: '/tmp/upload-metafiles' }
  });
  ```

  ```ts
  // use a separate bucket for metafiles
  const storage = new GCStorage({
    bucket: 'uploads',
    metaStorageConfig: { bucket: 'upload-metafiles' }
  });
  ```

- `metaStorage` option to use a custom metadata storage

- `saveMeta`, `getMeta`, `deleteMeta` methods for metafiles
