### PR TITLE
fix: expire cache entries

### DIFF
--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -6,10 +6,10 @@ export class Cache<T> {
 
   /**
    *
-   * @param limit The maximum number of entries before the cache starts flushing out the old items
-   * @param ttl The maximum life of a cached items in milliseconds
+   * @param maxEntries The maximum number of entries before the cache starts flushing out the old items
+   * @param maxAge The maximum life of a cached items in seconds
    */
-  constructor(public limit = 500, public ttl = 300_000) {}
+  constructor(public maxEntries = 500, public maxAge = 300) {}
 
   get(key: string): T | undefined {
     const [value, expiresAt] = this._map.get(key) || [];
@@ -17,7 +17,7 @@ export class Cache<T> {
       this._map.delete(key);
       const now = Date.now();
       if (expiresAt && now > expiresAt) return;
-      this._map.set(key, [value, now + this.ttl]);
+      this._map.set(key, [value, now + this.maxAge * 1000]);
     }
     return value;
   }
@@ -28,7 +28,7 @@ export class Cache<T> {
 
   set(key: string, value: T): void {
     if (this._map.has(key)) this._map.delete(key);
-    else if (this._map.size === this.limit) this._map.delete(this._map.keys().next().value);
-    this._map.set(key, [value, Date.now() + this.ttl]);
+    else if (this._map.size === this.maxEntries) this._map.delete(this._map.keys().next().value);
+    this._map.set(key, [value, Date.now() + this.maxAge * 1000]);
   }
 }

--- a/test/cache.spec.ts
+++ b/test/cache.spec.ts
@@ -4,7 +4,7 @@ describe('Cache', () => {
   let cache: Cache<any>;
 
   beforeEach(() => {
-    cache = new Cache(5, 500);
+    cache = new Cache(5, 60);
     for (let i = 0; i < 10; i++) {
       cache.set(`key-${i}`, i);
     }
@@ -18,7 +18,7 @@ describe('Cache', () => {
 
   it('should expire', async () => {
     jest.useFakeTimers();
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(100_000);
     expect(cache.get(`key-9`)).toBeUndefined();
     expect(cache['_map'].size).toBe(4);
   });

--- a/test/cache.spec.ts
+++ b/test/cache.spec.ts
@@ -1,0 +1,25 @@
+import { Cache } from '@uploadx/core';
+
+describe('Cache', () => {
+  let cache: Cache<any>;
+
+  beforeEach(() => {
+    cache = new Cache(5, 500);
+    for (let i = 0; i < 10; i++) {
+      cache.set(`key-${i}`, i);
+    }
+  });
+
+  it('should limit size', () => {
+    expect(cache.get(`key-0`)).toBeUndefined();
+    expect(cache.get(`key-9`)).toBe(9);
+    expect(cache['_map'].size).toBe(5);
+  });
+
+  it('should expire', async () => {
+    jest.useFakeTimers();
+    jest.advanceTimersByTime(1000);
+    expect(cache.get(`key-9`)).toBeUndefined();
+    expect(cache['_map'].size).toBe(4);
+  });
+});


### PR DESCRIPTION
If delete the download metafile, its contents may take a long time to be stored in the cache. This PR set cache TTL to 5 minutes.

Override example: 
```ts
const storage = new DiskStorage({ directory: 'uploads'});
storage.cache.maxAge = 40; 
```

