### PR TITLE
feat(storage): upload expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,21 +85,22 @@ Please navigate to the [examples](examples) for more.
 
 Some available options: :
 
-| option                |         type         |  default value   | description                                         |
-| :-------------------- | :------------------: | :--------------: | --------------------------------------------------- |
-| `directory`           |       `string`       |    `"files"`     | _DiskStorage upload directory_                      |
-| `bucket`              |       `string`       | `"node-uploadx"` | _S3 or GCS bucket_                                  |
-| `path`                |       `string`       |    `"/files"`    | _Node http base path_                               |
-| `allowMIME`           |      `string[]`      |    `["*\*"]`     | _Allowed MIME types_                                |
-| `maxUploadSize`       |   `string\|number`   |     `"5TB"`      | _File size limit_                                   |
-| `metaStorage`         |    `MetaStorage`     |                  | _Provide custom meta storage_                       |
-| `metaStorageConfig`   | `MetaStorageOptions` |                  | _Configure metafiles storage_                       |
-| `maxMetadataSize`     |   `string\|number`   |     `"4MB"`      | _Metadata size limit_                               |
-| `validation`          |     `Validation`     |                  | _Upload validation options_                         |
-| `useRelativeLocation` |      `boolean`       |     `false`      | _Use relative urls_                                 |
-| `filename`            |      `Function`      |                  | _Name generator function_                           |
-| `onComplete`          |     `OnComplete`     |                  | _On upload complete callback_                       |
-| `clientDirectUpload`  |      `boolean`       |                  | _Upload by a compatible client directly to the GCS_ |
+| option                |         type         |  default value   | description                                                  |
+| :-------------------- | :------------------: | :--------------: | ------------------------------------------------------------ |
+| `directory`           |       `string`       |    `"files"`     | _DiskStorage upload directory_                               |
+| `bucket`              |       `string`       | `"node-uploadx"` | _S3 or GCS bucket_                                           |
+| `path`                |       `string`       |    `"/files"`    | _Node http base path_                                        |
+| `allowMIME`           |      `string[]`      |    `["*\*"]`     | _Allowed MIME types_                                         |
+| `maxUploadSize`       |   `string\|number`   |     `"5TB"`      | _File size limit_                                            |
+| `metaStorage`         |    `MetaStorage`     |                  | _Provide custom meta storage_                                |
+| `metaStorageConfig`   | `MetaStorageOptions` |                  | _Configure metafiles storage_                                |
+| `maxMetadataSize`     |   `string\|number`   |     `"4MB"`      | _Metadata size limit_                                        |
+| `validation`          |     `Validation`     |                  | _Upload validation options_                                  |
+| `useRelativeLocation` |      `boolean`       |     `false`      | _Use relative urls_                                          |
+| `filename`            |      `Function`      |                  | _Name generator function_                                    |
+| `onComplete`          |     `OnComplete`     |                  | _On upload complete callback_                                |
+| `clientDirectUpload`  |      `boolean`       |                  | _Upload by a compatible client directly to the GCS_          |
+| `expiration`          | `ExpirationOptions`  |                  | _Configuring the cleanup of abandoned and completed uploads_ |
 
 For Google Cloud Storage authenticate see [GoogleAuthOptions](https://github.com/googleapis/google-auth-library-nodejs/blob/04dae9c271f0099025188489c61fd245d482832b/src/auth/googleauth.ts#L62). Also supported `GCS_BUCKET`, `GCS_KEYFILE` and `GOOGLE_APPLICATION_CREDENTIALS` environment variables.
 

--- a/examples/express-basic.ts
+++ b/examples/express-basic.ts
@@ -1,4 +1,4 @@
-import { DiskStorageOptions, multipart, uploadx } from '@uploadx/core';
+import { DiskStorageOptions, uploadx } from '@uploadx/core';
 import * as express from 'express';
 
 const app = express();
@@ -6,15 +6,14 @@ const app = express();
 const opts: DiskStorageOptions = {
   maxUploadSize: '1GB',
   allowMIME: ['video/*', 'image/*'],
+  expiration: { maxAge: '1h', purgeInterval: '10min' },
   onComplete: file => {
     console.log('File upload complete: ', file);
-    return file.status;
+    return file;
   }
 };
 
 app.use('/files', express.static('files'));
-
-app.use('/files', multipart(opts));
 
 app.use('/upload/files', uploadx(opts));
 

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -31,10 +31,11 @@ const storage = new DiskStorage({
   directory: 'upload',
   maxMetadataSize: '1mb',
   onComplete,
+  expiration: { maxAge: '1h', purgeInterval: '10min' },
   validation: {
     mime: { value: ['video/*'], response: [415, { message: 'video only' }] },
     size: {
-      value: 500_000,
+      value: 500_000_000,
       isValid(file) {
         this.response = [
           412,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "bytes": "^3.1.0",
     "debug": "^4.3.1",
-    "multiparty": "^4.2.2"
+    "multiparty": "^4.2.2",
+    "parse-duration": "^1.0.0"
   },
   "devDependencies": {
     "@types/bytes": "3.1.1",

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as http from 'http';
 import { resolve as pathResolve } from 'path';
 import { ensureFile, ERRORS, fail, fsp, getWriteStream, HttpError } from '../utils';
@@ -64,6 +65,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
 
   async write(part: FilePart): Promise<DiskFile> {
     const file = await this.getMeta(part.name);
+    await this.checkIfExpired(file);
     if (file.status === 'completed') return file;
     if (!isValidPart(part, file)) return fail(ERRORS.FILE_CONFLICT);
     try {

--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -1,19 +1,7 @@
 import { Readable } from 'stream';
 import { md5, uid } from '../utils';
 
-export class Timestamped {
-  expiredAt?: string | Date | number;
-  createdAt?: string | Date | number;
-}
-
-export function setExpirationTime<T extends Timestamped>(item: T, maxAgeMs: number): T {
-  if (item.createdAt) {
-    item.expiredAt ??= new Date(maxAgeMs + +new Date(item.createdAt)).toISOString();
-  }
-  return item;
-}
-
-export function isExpired(file: Timestamped): boolean {
+export function isExpired(file: File): boolean {
   if (!file.expiredAt) return false;
   return Date.now() > +new Date(file.expiredAt);
 }
@@ -43,7 +31,7 @@ export interface FileInit {
 
 export type UploadEventType = 'created' | 'completed' | 'deleted' | 'part' | 'updated';
 
-export class File implements FileInit, Timestamped {
+export class File implements FileInit {
   bytesWritten = NaN;
   contentType;
   originalName;

--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -61,7 +61,7 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
       name.endsWith(this.suffix) &&
         uploads.push({
           name: this.getNameFromPath(name),
-          created: (await fsp.stat(name)).ctime
+          createdAt: (await fsp.stat(name)).ctime
         });
     }
     return { items: uploads };

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -1,8 +1,9 @@
-import { Timestamped } from './file';
 /** @experimental */
-interface UploadListEntry extends Timestamped {
+interface UploadListEntry {
   /** upload name */
   name: string;
+  createdAt: string | Date | number;
+  expiredAt?: string | Date | number;
 }
 
 /** @experimental */

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -1,10 +1,13 @@
+import { Timestamped } from './file';
+/** @experimental */
+interface UploadListEntry extends Timestamped {
+  /** upload name */
+  name: string;
+}
+
 /** @experimental */
 export interface UploadList {
-  items: {
-    /** upload name */
-    name: string;
-    created: Date;
-  }[];
+  items: UploadListEntry[];
 }
 
 export interface MetaStorageOptions {

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -9,6 +9,7 @@ interface UploadListEntry {
 /** @experimental */
 export interface UploadList {
   items: UploadListEntry[];
+  prefix?: string;
 }
 
 export interface MetaStorageOptions {

--- a/packages/core/src/utils/primitives.ts
+++ b/packages/core/src/utils/primitives.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from 'crypto';
+import duration from 'parse-duration';
 
 export const pick = <T, K extends keyof T>(obj: T, whitelist: K[]): Pick<T, K> => {
   const result = {} as Pick<T, K>;
@@ -35,4 +36,18 @@ export function mapValues<T>(
     result[key] = func(object[key]);
   }
   return result;
+}
+
+export function isNumber(x?: unknown): x is number {
+  return x === Number(x);
+}
+
+/**
+ * convert a human-readable duration to ms
+ * @param value
+ */
+export function toMilliseconds(value: string | number | undefined): number | null {
+  if (isNumber(value)) return value;
+  if (!value) return null;
+  return duration(value);
 }

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -74,7 +74,7 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
         .filter(item => item.name.endsWith(this.suffix))
         .map(({ name, timeCreated }) => ({
           name: this.getNameFromPath(name),
-          created: new Date(timeCreated)
+          createdAt: new Date(timeCreated)
         }))
     };
   }

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -166,6 +166,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
 
   async write(part: FilePart): Promise<GCSFile> {
     const file = await this.getMeta(part.name);
+    await this.checkIfExpired(file);
     if (file.status === 'completed') return file;
     if (!isValidPart(part, file)) return fail(ERRORS.FILE_CONFLICT);
     file.bytesWritten = await this._write({ ...file, ...part });

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -66,7 +66,7 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
           Key.endsWith(this.suffix) &&
           items.push({
             name: Key?.slice(this.prefix.length, -this.suffix.length),
-            created: LastModified
+            createdAt: LastModified
           });
       }
     }

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -139,6 +139,7 @@ export class S3Storage extends BaseStorage<S3File> {
 
   async write(part: FilePart): Promise<S3File> {
     const file = await this.getMeta(part.name);
+    await this.checkIfExpired(file);
     if (file.status === 'completed') return file;
     if (!isValidPart(part, file)) return fail(ERRORS.FILE_CONFLICT);
     file.Parts ||= await this._getParts(file);

--- a/test/disk-storage.spec.ts
+++ b/test/disk-storage.spec.ts
@@ -159,12 +159,12 @@ describe('DiskStorage', () => {
     });
   });
 
-  describe('.purgeExpired()', () => {
+  describe('.purge()', () => {
     beforeEach(createFile);
 
     it('should delete file', async () => {
-      const deleted = await storage.purgeExpired(5);
-      expect(deleted).toHaveLength(1);
+      const list = await storage.purge(5);
+      expect(list.items).toHaveLength(1);
     });
   });
 });

--- a/test/disk-storage.spec.ts
+++ b/test/disk-storage.spec.ts
@@ -8,12 +8,16 @@ const directory = 'ds-test';
 let writeStream: FileWriteStream;
 
 jest.mock('../packages/core/src/utils/fs', () => {
+  const timestamp = Date.now() - 10000;
   return {
     ensureFile: async () => 0,
     getFiles: async () => [posix.join(directory, filename), posix.join(directory, metafile)],
     getWriteStream: () => writeStream,
     fsp: {
-      stat: async () => ({ mtime: new Date() }),
+      stat: async () => ({
+        mtime: timestamp,
+        ctime: timestamp
+      }),
       writeFile: async () => 0,
       readFile: async () => JSON.stringify(testfile),
       unlink: async () => null
@@ -121,17 +125,17 @@ describe('DiskStorage', () => {
     });
   });
 
-  describe('.get()', () => {
+  describe('.list()', () => {
     beforeEach(createFile);
 
     it('should return all user files', async () => {
-      const { items } = await storage.get(testfile.userId);
+      const { items } = await storage.list(testfile.userId);
       expect(items).toHaveLength(1);
       expect(items[0]).toMatchObject({ name: filename });
     });
 
     it('should return one file', async () => {
-      const { items } = await storage.get(filename);
+      const { items } = await storage.list(filename);
       expect(items).toHaveLength(1);
       expect(items[0]).toMatchObject({ name: filename });
     });
@@ -152,6 +156,15 @@ describe('DiskStorage', () => {
       const [deleted] = await storage.delete('notfound');
       expect(deleted.name).toBe('notfound');
       expect(deleted.status).toBeUndefined();
+    });
+  });
+
+  describe('.purgeExpired()', () => {
+    beforeEach(createFile);
+
+    it('should delete file', async () => {
+      const deleted = await storage.purgeExpired(5);
+      expect(deleted).toHaveLength(1);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4126,6 +4126,11 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-duration@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-1.0.0.tgz#8605651745f61088f6fb14045c887526c291858c"
+  integrity sha512-X4kUkCTHU1N/kEbwK9FpUJ0UZQa90VzeczfS704frR30gljxDG0pSziws06XlK+CGRSo/1wtG1mFIdBFQTMQNw==
+
 parse-json@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.1.0.tgz#f96088cdf24a8faa9aea9a009f2d9d942c999646"


### PR DESCRIPTION
- automatic cleaning of abandoned and completed uploads.

  ```typescript
  app.all(
    '/upload',
    uploadx.upload({
      directory: 'upload',
      expiration: { maxAge: '6h', purgeInterval: '30min' }
    }),
    onComplete
  );
  ```

- sends `Upload-Expires` headers to client
- sends `410 Gone` if the client tries to resume an expired upload
- `storage.purge(maxAge?: number | string, prefix?: string): Promise<PurgeList>` method to search for and delete upload files
