### PR TITLE
feat: extended completed file

### DIFF
--- a/examples/express-gcs.ts
+++ b/examples/express-gcs.ts
@@ -5,10 +5,10 @@ const app = express();
 
 const storage = new GCStorage({ maxUploadSize: '1GB' });
 
-storage.onComplete = ({ uri, id }) => {
-  console.log(`File upload complete, storage path: ${uri}`);
-  // send gcs link to client
-  return { id, link: uri };
+storage.onComplete = async file => {
+  const info = await file.get().catch(console.error);
+  console.log(info);
+  return file.move(file.originalName).catch(console.error);
 };
 
 app.use('/files', uploadx({ storage }));

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -133,6 +133,11 @@ export abstract class BaseHandler<TFile extends Readonly<File>>
         if ('status' in file && file.status) {
           this.log('[%s]: %s', file.status, file.name);
           this.listenerCount(file.status) && this.emit(file.status, file);
+          if (file.lockedBy instanceof Function) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            file.lockedBy();
+            return;
+          }
           if (file.status === 'completed') {
             req['_body'] = true;
             req['body'] = file;

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -67,16 +67,12 @@ export class DiskStorage extends BaseStorage<DiskFile> {
 
   buildCompletedFile(file: DiskFile): DiskFile {
     const completed = { ...file };
-    completed.lock = async lockFn => {
-      completed.lockedBy = lockFn;
-      return Promise.resolve(completed.lockedBy);
-    };
+    completed.lock = token => (completed.lockedBy = token);
     completed.delete = () => this.delete(file.name);
     completed.hash = (algorithm?: 'sha1' | 'md5', encoding?: 'hex' | 'base64') =>
       fileChecksum(this.getFilePath(file.name), algorithm, encoding);
     completed.copy = async (dest: string) => fsp.copyFile(this.getFilePath(file.name), dest);
     completed.move = async (dest: string) => move(this.getFilePath(file.name), dest);
-
     return completed;
   }
 

--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -43,6 +43,8 @@ export class File implements FileInit {
   userId?;
   expiredAt?: string | Date | number;
   createdAt?: string | Date | number;
+  lock!: (onLocked: () => any) => Promise<any>;
+  lockedBy?: (() => any) | unknown;
 
   constructor({ metadata = {}, originalName, contentType, size, userId }: FileInit) {
     this.metadata = metadata;

--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -43,8 +43,8 @@ export class File implements FileInit {
   userId?;
   expiredAt?: string | Date | number;
   createdAt?: string | Date | number;
-  lock!: (onLocked: () => any) => Promise<any>;
-  lockedBy?: (() => any) | unknown;
+  lock!: (token: unknown) => any;
+  lockedBy?: unknown;
 
   constructor({ metadata = {}, originalName, contentType, size, userId }: FileInit) {
     this.metadata = metadata;

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -1,6 +1,7 @@
 import * as http from 'http';
 import { Readable } from 'stream';
 import { Metadata } from '../storages';
+import { isNumber } from './primitives';
 
 export const typeis = (req: http.IncomingMessage, types: string[]): string | false => {
   const contentType = req.headers['content-type'] || '';
@@ -73,6 +74,11 @@ export interface UploadxResponse<T = ResponseBody> extends Record<string, any> {
   headers?: Headers;
   body?: T;
 }
+
+export function isUploadxResponse(value: unknown): value is UploadxResponse {
+  return !!(typeof value === 'object' && isNumber((value as UploadxResponse).statusCode));
+}
+
 export type ResponseBody = string | Record<string, any>;
 export type ResponseBodyType = 'text' | 'json';
 export type ResponseTuple<T = ResponseBody> = [statusCode: number, body?: T, headers?: Headers];

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -240,15 +240,11 @@ export class GCStorage extends BaseStorage<GCSFile> {
 
   buildCompletedFile(file: GCSFile): GCSFile {
     const completed = { ...file };
-    completed.lock = async lockFn => {
-      completed.lockedBy = lockFn;
-      return Promise.resolve(completed.lockedBy);
-    };
+    completed.lock = token => (completed.lockedBy = token);
     completed.get = () => this._get(file.name);
     completed.delete = () => this.delete(file.name);
     completed.copy = async (dest: string) => this.copy(file.name, dest);
     completed.move = async (dest: string) => this.move(file.name, dest);
-
     return completed;
   }
 

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -222,14 +222,10 @@ export class S3Storage extends BaseStorage<S3File> {
 
   buildCompletedFile(file: S3File): S3File {
     const completed = { ...file };
-    completed.lock = async lockFn => {
-      completed.lockedBy = lockFn;
-      return Promise.resolve(completed.lockedBy);
-    };
+    completed.lock = token => (completed.lockedBy = token);
     completed.delete = () => this.delete(file.name);
     completed.copy = async (dest: string) => this.copy(file.name, dest);
     completed.move = async (dest: string) => this.move(file.name, dest);
-
     return completed;
   }
 

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -37,10 +37,14 @@ import { S3MetaStorage, S3MetaStorageOptions } from './s3-meta-storage';
 
 const BUCKET_NAME = 'node-uploadx';
 
-export class S3File extends File {
+export interface S3File extends File {
   Parts?: Part[];
-  UploadId = '';
+  UploadId?: string;
   uri?: string;
+  lock: (lockFn: () => any) => Promise<any>;
+  move: (dest: any) => Promise<any>;
+  copy: (dest: any) => Promise<any>;
+  delete: () => Promise<any>;
 }
 
 export type S3StorageOptions = BaseStorageOptions<S3File> &
@@ -121,7 +125,7 @@ export class S3Storage extends BaseStorage<S3File> {
   }
 
   async create(req: http.IncomingMessage, config: FileInit): Promise<S3File> {
-    const file = new S3File(config);
+    const file = new File(config) as S3File;
     file.name = this.namingFunction(file);
     await this.validate(file);
     try {
@@ -226,7 +230,7 @@ export class S3Storage extends BaseStorage<S3File> {
   }
 
   private _checkBucket(): void {
-    this.client.send(new HeadBucketCommand({ Bucket: this.bucket }), (err: AWSError, data) => {
+    this.client.send(new HeadBucketCommand({ Bucket: this.bucket }), (err: AWSError) => {
       if (err) {
         throw err;
       }

--- a/test/disk-storage.spec.ts
+++ b/test/disk-storage.spec.ts
@@ -1,5 +1,5 @@
 import { posix } from 'path';
-import { DiskStorage, fsp } from '../packages/core/src';
+import { DiskStorage, DiskStorageOptions, fsp } from '../packages/core/src';
 import { storageOptions } from './fixtures';
 import { FileWriteStream, RequestReadStream } from './fixtures/streams';
 import { filename, metafile, testfile } from './fixtures/testfile';
@@ -26,7 +26,7 @@ jest.mock('../packages/core/src/utils/fs', () => {
 });
 
 describe('DiskStorage', () => {
-  const options = { ...storageOptions, directory };
+  const options = { ...storageOptions, directory } as DiskStorageOptions;
   let storage: DiskStorage;
   let mockReadable: RequestReadStream;
   const createFile = (): Promise<any> => {

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { join } from 'path';
 import * as request from 'supertest';
-import { multipart } from '../packages/core/src';
+import { multipart, DiskStorageOptions } from '../packages/core/src';
 import { root, storageOptions } from './fixtures';
 import { app } from './fixtures/app';
 import { metadata, srcpath } from './fixtures/testfile';
@@ -12,7 +12,7 @@ describe('::Multipart', () => {
   const files: string[] = [];
   const basePath = '/multipart';
   const directory = join(root, 'multipart');
-  const opts = { ...storageOptions, directory };
+  const opts = { ...storageOptions, directory } as DiskStorageOptions;
   app.use(basePath, multipart(opts));
 
   beforeAll(() => cleanup(directory));

--- a/test/s3-storage.spec.ts
+++ b/test/s3-storage.spec.ts
@@ -3,6 +3,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 
 import {
   CompleteMultipartUploadCommand,
+  CopyObjectCommand,
   CreateMultipartUploadCommand,
   DeleteObjectCommand,
   HeadObjectCommand,
@@ -125,6 +126,30 @@ describe('S3Storage', () => {
       s3Mock.on(DeleteObjectCommand).resolves({});
       const [deleted] = await storage.delete(filename);
       expect(deleted.status).toBe('deleted');
+    });
+  });
+
+  describe('copy()', () => {
+    it('relative', async () => {
+      s3Mock.resetHistory();
+      s3Mock.on(CopyObjectCommand).resolves({});
+      await storage.copy('name', 'new name');
+      expect(s3Mock.call(0).args[0].input).toStrictEqual({
+        Bucket: 'node-uploadx',
+        CopySource: 'node-uploadx/name',
+        Key: 'new name'
+      });
+    });
+
+    it('absolute', async () => {
+      s3Mock.resetHistory();
+      s3Mock.on(CopyObjectCommand).resolves({});
+      await storage.copy('name', '/otherBucket/new name');
+      expect(s3Mock.call(0).args[0].input).toStrictEqual({
+        Bucket: 'otherBucket',
+        CopySource: 'node-uploadx/name',
+        Key: 'new name'
+      });
     });
   });
 });

--- a/test/s3-storage.spec.ts
+++ b/test/s3-storage.spec.ts
@@ -36,7 +36,7 @@ describe('S3Storage', () => {
       ...testfile,
       UploadId: '123456789',
       Parts: []
-    };
+    } as unknown as S3File;
   });
 
   describe('.create()', () => {

--- a/test/tus.spec.ts
+++ b/test/tus.spec.ts
@@ -2,7 +2,13 @@
 import * as fs from 'fs';
 import { join } from 'path';
 import * as request from 'supertest';
-import { BaseStorage, serializeMetadata, tus, TUS_RESUMABLE } from '@uploadx/core';
+import {
+  BaseStorage,
+  DiskStorageOptions,
+  serializeMetadata,
+  tus,
+  TUS_RESUMABLE
+} from '@uploadx/core';
 import { root, storageOptions } from './fixtures';
 import { app } from './fixtures/app';
 import { metadata, srcpath } from './fixtures/testfile';
@@ -12,7 +18,7 @@ describe('::Tus', () => {
   let uri: string;
   const basePath = '/tus';
   const directory = join(root, 'tus');
-  const opts = { ...storageOptions, directory };
+  const opts = { ...storageOptions, directory } as DiskStorageOptions;
   app.use(basePath, tus(opts));
 
   beforeAll(() => cleanup(directory));

--- a/test/uploadx.spec.ts
+++ b/test/uploadx.spec.ts
@@ -2,7 +2,7 @@
 import * as fs from 'fs';
 import { join } from 'path';
 import * as request from 'supertest';
-import { uploadx } from '../packages/core/src';
+import { uploadx, DiskStorageOptions } from '../packages/core/src';
 import { root, storageOptions, userPrefix } from './fixtures';
 import { app } from './fixtures/app';
 import { metadata, srcpath } from './fixtures/testfile';
@@ -13,7 +13,7 @@ describe('::Uploadx', () => {
   let start: number;
   const basePath = '/uploadx';
   const directory = join(root, 'uploadx');
-  const opts = { ...storageOptions, directory, maxMetadataSize: 250 };
+  const opts = { ...storageOptions, directory, maxMetadataSize: 250 } as DiskStorageOptions;
   app.use(basePath, uploadx(opts));
 
   beforeAll(() => cleanup(directory));


### PR DESCRIPTION
ex:
```ts
import * as express from 'express';
import { DiskFile, uploadx } from '@uploadx/core';
import { join } from 'path';

const app = express();

const onComplete: express.RequestHandler = async (req, res, next) => {
  const file = req.body as DiskFile;
  await file.lock(() => ({ statusCode: 202 }));
  const sha1 = await file.hash('sha1');
  await file.move(join('upload', file.originalName));
  await file.lock(() => ({ body: { ...file, sha1 }, statusCode: 200 }));
  if (res.headersSent) return;
  return res.json({ ...file, sha1 });
};

app.all(
  '/files',
  uploadx.upload({
    directory: 'upload',
    expiration: { maxAge: '12h', purgeInterval: '1h' }
  }),
  onComplete
);

app.listen(3002, () => {
  console.log('listening on port:', 3002);
});
```
