### PR TITLE
feat(core): extend filename function

### DIFF
--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -52,7 +52,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
 
   async create(req: http.IncomingMessage, fileInit: FileInit): Promise<DiskFile> {
     const file = new DiskFile(fileInit);
-    file.name = this.namingFunction(file);
+    file.name = this.namingFunction(file, req);
     await this.validate(file);
     const path = this.getFilePath(file.name);
     file.bytesWritten = await ensureFile(path).catch(e => fail(ERRORS.FILE_ERROR, e));

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -46,7 +46,7 @@ export interface BaseStorageOptions<T extends File> {
   /** File size limit */
   maxUploadSize?: number | string;
   /** Name generator function */
-  filename?: (file: T) => string;
+  filename?: (file: T, req: any) => string;
   useRelativeLocation?: boolean;
   /** Completed callback */
   onComplete?: OnComplete<T>;
@@ -94,7 +94,7 @@ export abstract class BaseStorage<TFile extends File> {
   errorResponses = {} as ErrorResponses;
   cache: Cache<TFile>;
   protected log = Logger.get(`${this.constructor.name}`);
-  protected namingFunction: (file: TFile) => string;
+  protected namingFunction: (file: TFile, req: any) => string;
   protected validation = new Validator<TFile>();
   abstract meta: MetaStorage<TFile>;
 

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -132,7 +132,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
 
   async create(req: http.IncomingMessage, config: FileInit): Promise<GCSFile> {
     const file = new GCSFile(config);
-    file.name = this.namingFunction(file);
+    file.name = this.namingFunction(file, req);
     await this.validate(file);
     try {
       const existing = await this.getMeta(file.name);

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -122,7 +122,7 @@ export class S3Storage extends BaseStorage<S3File> {
 
   async create(req: http.IncomingMessage, config: FileInit): Promise<S3File> {
     const file = new S3File(config);
-    file.name = this.namingFunction(file);
+    file.name = this.namingFunction(file, req);
     await this.validate(file);
     try {
       const existing = await this.getMeta(file.name);


### PR DESCRIPTION
Add request to the `filename` function parameters:  `filename?: (file: T, req: any) => string;`

ex:
```ts
app.use(
  '/files',
  uploadx.upload({
    directory: 'upload',
    filename: (file, req: express.Request) =>
      `${(req.headers.folder as string) || 'files'}/${file.originalName}`,
  })
);
```