### PR TITLE
fix(tus): support metadata empty values

### DIFF
--- a/packages/core/src/handlers/tus.ts
+++ b/packages/core/src/handlers/tus.ts
@@ -13,12 +13,9 @@ export function serializeMetadata(obj: Metadata): string {
 
 export function parseMetadata(encoded = ''): Metadata {
   const kvPairs = encoded.split(',').map(kv => kv.split(' '));
-  const metadata = Object.create(null) as Record<string, string>;
+  const metadata = Object.create(Metadata.prototype) as Record<string, string>;
   for (const [key, value] of kvPairs) {
-    if (!value || !key) {
-      return metadata;
-    }
-    metadata[key] = Buffer.from(value, 'base64').toString();
+    if (key) metadata[key] = value ? Buffer.from(value, 'base64').toString() : '';
   }
   return metadata;
 }

--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -77,7 +77,7 @@ export function isValidPart(part: FilePart, file: File): boolean {
 }
 
 /** User-provided metadata */
-export interface Metadata {
+export class Metadata {
   [key: string]: any;
 
   size?: string | number;

--- a/test/tus.spec.ts
+++ b/test/tus.spec.ts
@@ -132,19 +132,25 @@ describe('::Tus', () => {
       expect(parseMetadata(sample)).toEqual({});
     });
 
-    it('should parse single key', () => {
+    it('should parse single key/value', () => {
       const sample = 'name dGl0bGUubXA0';
       expect(parseMetadata(sample)).toEqual({ name: 'title.mp4' });
     });
 
+    it('should parse empty value', () => {
+      const sample = 'is_ok';
+      expect(parseMetadata(sample)).toEqual({ is_ok: '' });
+    });
+
     it('should parse multiple keys', () => {
       const sample =
-        'name dGl0bGUubXA0,mimeType dmlkZW8vbXA0,size ODM4NjkyNTM=,lastModified MTQzNzM5MDEzODIzMQ==';
+        'name dGl0bGUubXA0,mimeType dmlkZW8vbXA0,size ODM4NjkyNTM=,lastModified MTQzNzM5MDEzODIzMQ==,is_ok';
       expect(parseMetadata(sample)).toEqual({
         name: 'title.mp4',
         mimeType: 'video/mp4',
         size: '83869253',
-        lastModified: '1437390138231'
+        lastModified: '1437390138231',
+        is_ok: ''
       });
     });
   });


### PR DESCRIPTION
The header  `Upload-Metadata: 'name bmFtZS5leHQ=,is_ok'` must be parsed as

```ts
{ name: 'name.ext', is_ok: '' }
```

also kukhariev/ngx-uploadx#354