### PR TITLE
refactor(gcs): allow override api urls

### DIFF
--- a/packages/gcs/src/constants.ts
+++ b/packages/gcs/src/constants.ts
@@ -1,4 +1,0 @@
-export const BUCKET_NAME = 'node-uploadx';
-export const uploadAPI = `https://storage.googleapis.com/upload/storage/v1/b`;
-export const storageAPI = `https://storage.googleapis.com/storage/v1/b`;
-export const authScopes = ['https://www.googleapis.com/auth/devstorage.full_control'];

--- a/packages/gcs/src/gcs-config.ts
+++ b/packages/gcs/src/gcs-config.ts
@@ -1,0 +1,6 @@
+export class GCSConfig {
+  static bucketName = 'node-uploadx';
+  static uploadAPI = `https://storage.googleapis.com/upload/storage/v1/b`;
+  static storageAPI = `https://storage.googleapis.com/storage/v1/b`;
+  static authScopes = ['https://www.googleapis.com/auth/devstorage.full_control'];
+}

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -1,6 +1,6 @@
-import { File, UploadList, MetaStorage, MetaStorageOptions } from '@uploadx/core';
+import { File, MetaStorage, MetaStorageOptions, UploadList } from '@uploadx/core';
 import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
-import { authScopes, BUCKET_NAME, storageAPI, uploadAPI } from './constants';
+import { GCSConfig } from './gcs-config';
 
 export interface GCSMetaStorageOptions extends GoogleAuthOptions, MetaStorageOptions {
   bucket?: string;
@@ -13,12 +13,12 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
 
   constructor(readonly config: GCSMetaStorageOptions = {}) {
     super(config);
-    config.scopes ||= authScopes;
     config.keyFile ||= process.env.GCS_KEYFILE;
-    const bucketName = config.bucket || process.env.GCS_BUCKET || BUCKET_NAME;
-    this.storageBaseURI = [storageAPI, bucketName, 'o'].join('/');
+    const bucketName = config.bucket || process.env.GCS_BUCKET || GCSConfig.bucketName;
+    this.storageBaseURI = [GCSConfig.storageAPI, bucketName, 'o'].join('/');
+    this.uploadBaseURI = [GCSConfig.uploadAPI, bucketName, 'o'].join('/');
+    config.scopes ||= GCSConfig.authScopes;
     this.authClient = new GoogleAuth(config);
-    this.uploadBaseURI = [uploadAPI, bucketName, 'o'].join('/');
   }
 
   getMetaName = (name: string): string => this.prefix + name + this.suffix;

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -19,7 +19,7 @@ import { AbortController } from 'abort-controller';
 import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
 import * as http from 'http';
 import request from 'node-fetch';
-import { authScopes, BUCKET_NAME, storageAPI, uploadAPI } from './constants';
+import { GCSConfig } from './gcs-config';
 import { GCSMetaStorage, GCSMetaStorageOptions } from './gcs-meta-storage';
 
 export interface ClientError extends Error {
@@ -108,11 +108,12 @@ export class GCStorage extends BaseStorage<GCSFile> {
           ? new LocalMetaStorage(metaConfig)
           : new GCSMetaStorage(metaConfig);
     }
-    config.scopes ||= authScopes;
+
     config.keyFile ||= process.env.GCS_KEYFILE;
-    this.bucket = config.bucket || process.env.GCS_BUCKET || BUCKET_NAME;
-    this.storageBaseURI = [storageAPI, this.bucket, 'o'].join('/');
-    this.uploadBaseURI = [uploadAPI, this.bucket, 'o'].join('/');
+    this.bucket = config.bucket || process.env.GCS_BUCKET || GCSConfig.bucketName;
+    this.storageBaseURI = [GCSConfig.storageAPI, this.bucket, 'o'].join('/');
+    this.uploadBaseURI = [GCSConfig.uploadAPI, this.bucket, 'o'].join('/');
+    config.scopes ||= GCSConfig.authScopes;
     this.authClient = new GoogleAuth(config);
 
     this.accessCheck().catch((err: ClientError) => {
@@ -236,6 +237,6 @@ export class GCStorage extends BaseStorage<GCSFile> {
   };
 
   private accessCheck(): Promise<any> {
-    return this.authClient.request({ url: `${storageAPI}/${this.bucket}` });
+    return this.authClient.request({ url: `${GCSConfig.storageAPI}/${this.bucket}` });
   }
 }

--- a/packages/gcs/src/index.ts
+++ b/packages/gcs/src/index.ts
@@ -1,3 +1,3 @@
 export * from './gcs-storage';
 export * from './gcs-meta-storage';
-export * from './constants';
+export * from './gcs-config';


### PR DESCRIPTION
Moved API urls to `GCSConfig` class static props.
