### PR TITLE
fix: `post` request body size limit

### DIFF
--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -50,9 +50,9 @@ export async function getMetadata(
   req: IncomingMessageWithBody<Record<any, any>>,
   limit = 16777216
 ): Promise<Record<any, any>> {
-  if (typeis.hasBody(req) > limit) return Promise.reject('body length limit');
   if (!typeis(req, ['json'])) return {};
   if (req.body) return { ...req.body };
+  if (typeis.hasBody(req) > limit) return Promise.reject('body length limit');
   const raw = await readBody(req, 'utf8', limit);
   return { ...JSON.parse(raw) } as Record<any, any>;
 }

--- a/test/uploadx.spec.ts
+++ b/test/uploadx.spec.ts
@@ -62,6 +62,11 @@ describe('::Uploadx', () => {
       expect(res.header).not.toHaveProperty('location');
     });
 
+    it('should ignore not json body', async () => {
+      const res = await request(app).post(path1).send(new Array(500).join('c')).expect(201);
+      expect(res.header).toHaveProperty('location');
+    });
+
     it('should check filename', async () => {
       const res = await create({ ...file1, name: '../ghost' }).expect(400);
       expect(res.type).toBe('application/json');


### PR DESCRIPTION
Do not limit the size of the non-json  post request body 