### PR TITLE
feat(core): support chunk checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # node-uploadx
 
 [![npm version][npm-image]][npm-url] [![Build status][gha-image]][gha-url]
-[![commits since latest release][comm-image]][comm-url] [![Snyk Vulnerabilities][snyk-image]][snyk-url]
+[![commits since latest release][comm-image]][comm-url]
 
 > Node.js resumable upload middleware.
 > Server-side part of [ngx-uploadx](https://github.com/kukhariev/ngx-uploadx)
 > Supported APIs: Google resumable v3.0, tus 1.0, multipart upload.
-> Capable store uploads locally on disk, on Google Storage or on AWS S3.
+> Capable store uploads locally on disk, on Google Storage or on S3.
 
 ## 🌩 Installation
 
@@ -30,7 +30,7 @@ Separate modules can also be used to save disk space and for faster installation
   npm install @uploadx/gcs
   ```
 
-- _AWS S3_ support:
+- _S3_ support:
 
   ```sh
   npm install @uploadx/s3
@@ -105,7 +105,7 @@ Some available options: :
 
 For Google Cloud Storage authenticate see [GoogleAuthOptions](https://github.com/googleapis/google-auth-library-nodejs/blob/04dae9c271f0099025188489c61fd245d482832b/src/auth/googleauth.ts#L62). Also supported `GCS_BUCKET`, `GCS_KEYFILE` and `GOOGLE_APPLICATION_CREDENTIALS` environment variables.
 
-For AWS S3 - [Setting Credentials in Node.js](https://docs.aws.amazon.com/en_us/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) and `S3_BUCKET`, `S3_KEYFILE` environment variable.
+For S3 buckets - [Setting Credentials in Node.js](https://docs.aws.amazon.com/en_us/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) and `S3_BUCKET`, `S3_KEYFILE` environment variable.
 
 ## References
 
@@ -127,5 +127,3 @@ Pull requests are welcome!
 [gha-url]: https://github.com/kukhariev/node-uploadx
 [comm-image]: https://img.shields.io/github/commits-since/kukhariev/node-uploadx/latest
 [comm-url]: https://github.com/kukhariev/node-uploadx/releases/latest
-[snyk-image]: https://img.shields.io/snyk/vulnerabilities/npm/node-uploadx
-[snyk-url]: https://snyk.io/test/github/kukhariev/node-uploadx?targetFile=package.json

--- a/examples/express-tus.ts
+++ b/examples/express-tus.ts
@@ -1,14 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import * as express from 'express';
-import { promises } from 'fs';
-import { join } from 'path';
 import { DiskFile, DiskStorageOptions, tus } from '@uploadx/core';
 
 const PORT = process.env.PORT || 3002;
 
 const app = express();
 const uploadDirectory = 'upload';
-const moveTo = 'files';
 const opts: DiskStorageOptions = {
   allowMIME: ['image/*', 'video/*'],
   directory: uploadDirectory
@@ -17,7 +14,6 @@ const opts: DiskStorageOptions = {
 app.use('/files', tus.upload(opts), async (req, res) => {
   const file = req.body as DiskFile;
   console.log('File upload complete: ', file.originalName);
-  await promises.rename(join(uploadDirectory, file.name), join(moveTo, file.originalName));
   return res.json(file);
 });
 

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -88,6 +88,9 @@ export class DiskStorage extends BaseStorage<DiskFile> {
       await this.saveMeta(file);
     }
     if (!isValidPart(part, file)) return fail(ERRORS.FILE_CONFLICT);
+    if (part.checksum && !this.checksumTypes.includes(part.checksumAlgorithm || '')) {
+      return fail(ERRORS.UNSUPPORTED_CHECKSUM_ALGORITHM);
+    }
     try {
       file.bytesWritten = await this._write({ ...file, ...part });
       if (file.bytesWritten === INVALID_OFFSET) return fail(ERRORS.FILE_CONFLICT);

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -7,14 +7,17 @@ import {
   fail,
   getWriteStream,
   HttpError,
-  removeFile
+  removeFile,
+  truncateFile
 } from '../utils';
 import { File, FileInit, FilePart, getFileStatus, hasContent, isValidPart } from './file';
 import { BaseStorage, BaseStorageOptions } from './storage';
 import { MetaStorage } from './meta-storage';
 import { LocalMetaStorage, LocalMetaStorageOptions } from './local-meta-storage';
+import { createHash } from 'crypto';
 
 const INVALID_OFFSET = -1;
+const CHECKSUM_MISMATCH = -2;
 
 export class DiskFile extends File {}
 
@@ -88,6 +91,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     try {
       file.bytesWritten = await this._write({ ...file, ...part });
       if (file.bytesWritten === INVALID_OFFSET) return fail(ERRORS.FILE_CONFLICT);
+      if (file.bytesWritten === CHECKSUM_MISMATCH) return fail(ERRORS.CHECKSUM_MISMATCH);
       file.status = getFileStatus(file);
       if (file.status === 'completed') await this.saveMeta(file);
       return file;
@@ -118,6 +122,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
       const path = this.getFilePath(part);
       if (hasContent(part)) {
         const file = getWriteStream(path, part.start);
+        const hash = createHash(part.checksumAlgorithm || 'sha1');
         file.once('error', error => reject(error));
         const body = part.body;
         body.once('aborted', () => {
@@ -129,10 +134,21 @@ export class DiskStorage extends BaseStorage<DiskFile> {
           start += chunk.length;
           if (start > part.size) {
             file.close();
+            void truncateFile(path, part.start);
             return resolve(INVALID_OFFSET);
           }
+          if (part.checksum) hash.update(chunk as string);
         });
-        body.pipe(file).on('finish', () => resolve(part.start + file.bytesWritten));
+        body.pipe(file).on('finish', () => {
+          const digest = hash.digest('base64');
+          if (part.checksum && digest !== part.checksum) {
+            file.close();
+            void truncateFile(path, part.start);
+            return resolve(CHECKSUM_MISMATCH);
+          }
+
+          resolve(part.start + file.bytesWritten);
+        });
       } else {
         resolve(ensureFile(path));
       }

--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -56,7 +56,7 @@ export class File implements FileInit {
 
 export type UploadxFile = Readonly<File>;
 
-export interface FilePart {
+export interface FilePart extends Checksum {
   body?: Readable;
   contentLength?: number;
   id: string;
@@ -135,3 +135,8 @@ export class FileName {
     }
   }
 }
+
+export type Checksum = {
+  checksum?: string;
+  checksumAlgorithm?: string;
+};

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -92,6 +92,7 @@ export abstract class BaseStorage<TFile extends File> {
   maxMetadataSize: number;
   path: string;
   isReady = true;
+  checksumTypes = ['md5', 'sha1', 'sha256'];
   errorResponses = {} as ErrorResponses;
   cache: Cache<TFile>;
   protected log = Logger.get(`${this.constructor.name}`);

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -21,7 +21,8 @@ export enum ERRORS {
   TOO_MANY_REQUESTS = 'TooManyRequests',
   UNKNOWN_ERROR = 'UnknownError',
   UNPROCESSABLE_ENTITY = 'UnprocessableEntity',
-  UNSUPPORTED_MEDIA_TYPE = 'UnsupportedMediaType'
+  UNSUPPORTED_MEDIA_TYPE = 'UnsupportedMediaType',
+  CHECKSUM_MISMATCH = 'ChecksumMismatch'
 }
 
 export type ErrorResponses<T extends string = string> = {
@@ -45,6 +46,7 @@ class E_ {
     InvalidRange: [400, 'Invalid or missing content-range header'],
     MethodNotAllowed: [405, 'Method not allowed'],
     RequestEntityTooLarge: [413, 'Request entity too large'],
+    ChecksumMismatch: [460, 'Checksum mismatch'],
     StorageError: [503, 'Storage error'],
     TooManyRequests: [429, 'Too many requests'],
     UnknownError: [500, 'Something went wrong'],

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -22,7 +22,8 @@ export enum ERRORS {
   UNKNOWN_ERROR = 'UnknownError',
   UNPROCESSABLE_ENTITY = 'UnprocessableEntity',
   UNSUPPORTED_MEDIA_TYPE = 'UnsupportedMediaType',
-  CHECKSUM_MISMATCH = 'ChecksumMismatch'
+  CHECKSUM_MISMATCH = 'ChecksumMismatch',
+  UNSUPPORTED_CHECKSUM_ALGORITHM = 'UnsupportedChecksumAlgorithm'
 }
 
 export type ErrorResponses<T extends string = string> = {
@@ -47,6 +48,7 @@ class E_ {
     MethodNotAllowed: [405, 'Method not allowed'],
     RequestEntityTooLarge: [413, 'Request entity too large'],
     ChecksumMismatch: [460, 'Checksum mismatch'],
+    UnsupportedChecksumAlgorithm: [400, 'Unsupported checksum algorithm'],
     StorageError: [503, 'Storage error'],
     TooManyRequests: [429, 'Too many requests'],
     UnknownError: [500, 'Something went wrong'],

--- a/packages/core/src/utils/fs.ts
+++ b/packages/core/src/utils/fs.ts
@@ -32,6 +32,10 @@ export async function removeFile(path: string): Promise<void> {
   return fsp.unlink(path);
 }
 
+export function truncateFile(path: string, length = 0): Promise<void> {
+  return fsp.truncate(path, length);
+}
+
 /**
  * Returns file WriteStream for data appending
  */

--- a/test/disk-storage.spec.ts
+++ b/test/disk-storage.spec.ts
@@ -18,6 +18,7 @@ jest.mock('../packages/core/src/utils/fs', () => {
     ensureFile: async () => 0,
     accessCheck: async () => 0,
     removeFile: async () => null,
+    truncateFile: async () => null,
     getFiles: async () => [
       posix.join(directory, testfile.name),
       posix.join(directory, metafilename)

--- a/test/shared/testfile.ts
+++ b/test/shared/testfile.ts
@@ -10,7 +10,8 @@ export const metadata = {
   size: 80495,
   mimeType: 'video/mp4',
   lastModified: 1635398061454,
-  custom: ''
+  custom: '',
+  sha1: 'YD5eezxkTfmNFCZ2SUA+ZjYcLyg='
 };
 
 export const testfile = {

--- a/test/tus.spec.ts
+++ b/test/tus.spec.ts
@@ -73,6 +73,7 @@ describe('::Tus', () => {
         .set('Upload-Metadata', serializeMetadata(metadata))
         .set('Upload-Offset', '0')
         .set('Tus-Resumable', TUS_RESUMABLE)
+        .set('Upload-Checksum', `sha1 ${metadata.sha1}`)
         .send(fs.readFileSync(srcpath))
         .expect(200)
         .expect('tus-resumable', TUS_RESUMABLE)
@@ -119,7 +120,12 @@ describe('::Tus', () => {
         .expect(204)
         .expect('tus-resumable', TUS_RESUMABLE);
       expect(exposedHeaders(res)).toEqual(
-        expect.arrayContaining(['tus-extension', 'tus-max-size', 'tus-resumable'])
+        expect.arrayContaining([
+          'tus-extension',
+          'tus-max-size',
+          'tus-resumable',
+          'tus-checksum-algorithm'
+        ])
       );
     });
   });

--- a/test/uploadx.spec.ts
+++ b/test/uploadx.spec.ts
@@ -184,6 +184,15 @@ describe('::Uploadx', () => {
         .expect('range', 'bytes=0-4');
     });
 
+    it('should 400 (invalid checksum algorithm)', async () => {
+      const res = await create({ ...file2, name: 'invalid checksum' });
+      await request(app)
+        .put(res.header.location as string)
+        .set('Digest', 'crc=798797')
+        .send(fs.readFileSync(srcpath))
+        .expect(400);
+    });
+
     it('should 409 (invalid size)', async () => {
       const res = await create({ ...file2, size: 15, name: 'size.409' });
       await request(app)

--- a/test/uploadx.spec.ts
+++ b/test/uploadx.spec.ts
@@ -112,7 +112,11 @@ describe('::Uploadx', () => {
   describe('PUT', () => {
     it('should 200 (simple request)', async () => {
       uri2 ||= (await create(file2)).header.location;
-      const res = await request(app).put(uri2).send(fs.readFileSync(srcpath)).expect(200);
+      const res = await request(app)
+        .put(uri2)
+        .set('Digest', `sha=${metadata.sha1}`)
+        .send(fs.readFileSync(srcpath))
+        .expect(200);
       expect(res.type).toBe('application/json');
       expect(fs.statSync(join(directory, userId, file2.name)).size).toBe(file2.size);
     });


### PR DESCRIPTION
- support tus checksum  extension
-  experimental support [Digest headers ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Digest)to verify data integrity of each chunk request.  460 status code will be returned if the checksums do not match.

 
```http
  PUT http://example.com/upload?upload_id=471e97554f21dec3b8bb5d4602939c51
  Content-Type: application/octet-stream
  Content-Range: bytes 0-262143/2469036б
  Digest: sha=gD5eezxkTfmNFCZ2SUA+ZjYcLyg=
  Content-Length: 262144

 [BYTES 0-262143]
```

closes #518