### PR TITLE
feat: rolling expiration

### DIFF
--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -82,7 +82,6 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     if (file.status === 'completed') return file;
     if (part.size && part.size < file.size) {
       file.size = part.size;
-      await this.saveMeta(file);
     }
     if (!isValidPart(part, file)) return fail(ERRORS.FILE_CONFLICT);
     try {

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -96,12 +96,12 @@ export class DiskStorage extends BaseStorage<DiskFile> {
   }
 
   async delete({ id }: FilePart): Promise<DiskFile[]> {
-    const file = await this.getMeta(id).catch(() => null);
-    if (file) {
-      await removeFile(this.getFilePath(file)).catch(() => null);
+    try {
+      const file = await this.getMeta(id);
+      await removeFile(this.getFilePath(file));
       await this.deleteMeta(id);
       return [{ ...file, status: 'deleted' }];
-    }
+    } catch {}
     return [{ id } as DiskFile];
   }
 

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -72,7 +72,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     const path = this.getFilePath(file);
     file.bytesWritten = await ensureFile(path).catch(e => fail(ERRORS.FILE_ERROR, e));
     file.status = getFileStatus(file);
-    if (file.status === 'created') await this.saveMeta(file);
+    await this.saveMeta(file);
     return file;
   }
 
@@ -89,7 +89,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
       file.bytesWritten = await this._write({ ...file, ...part });
       if (file.bytesWritten === INVALID_OFFSET) return fail(ERRORS.FILE_CONFLICT);
       file.status = getFileStatus(file);
-      if (file.status === 'completed') await this.saveMeta(file);
+      await this.saveMeta(file);
       return file;
     } catch (err) {
       return fail(ERRORS.FILE_ERROR, err);

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -6,6 +6,7 @@ export interface UploadListEntry {
   id: string;
   createdAt: string | Date | number;
   expiredAt?: string | Date | number;
+  modifiedAt?: string | Date | number;
 }
 
 /** @experimental */
@@ -52,6 +53,13 @@ export class MetaStorage<T> {
    */
   async get(id: string): Promise<T> {
     return Promise.reject();
+  }
+
+  /**
+   * Mark upload active
+   */
+  async touch(id: string, file: T): Promise<T> {
+    return file;
   }
 
   /**

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -8,7 +8,7 @@ import {
   ERRORS,
   fail,
   HttpError,
-  isMatch,
+  isEqual,
   Logger,
   toMilliseconds,
   typeis,
@@ -157,7 +157,7 @@ export abstract class BaseStorage<TFile extends File> {
   async saveMeta(file: TFile): Promise<TFile> {
     this.updateTimestamps(file);
     const prev = this.cache.get(file.id) || {};
-    if (isMatch(prev, file, 'bytesWritten')) {
+    if (isEqual(prev, file, 'bytesWritten')) {
       return this.meta.touch(file.id, file);
     }
     this.cache.set(file.id, file);

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -206,15 +206,15 @@ export abstract class BaseStorage<TFile extends File> {
     const purged = { items: [], maxAgeMs, prefix } as PurgeList;
     if (maxAgeMs) {
       const before = Date.now() - maxAgeMs;
-      const entries = (await this.list(prefix)).items.filter(
-        item => +new Date(item.modifiedAt || item.createdAt) < before
+      const expired = (await this.list(prefix)).items.filter(
+        item => +new Date(maxAge ? item.modifiedAt || item.createdAt : item.createdAt) < before
       );
-      for (const { id, createdAt, modifiedAt } of entries) {
+      for (const { id, ...rest } of expired) {
         const [deleted] = await this.delete({ id });
-        purged.items.push({ ...deleted, createdAt, modifiedAt });
+        purged.items.push({ ...deleted, ...rest });
       }
+      purged.items.length && this.log(`Purge: removed ${purged.items.length} uploads`);
     }
-    purged.items.length && this.log(`Purge: removed ${purged.items.length} uploads`);
     return purged;
   }
 

--- a/packages/core/src/utils/primitives.ts
+++ b/packages/core/src/utils/primitives.ts
@@ -39,13 +39,13 @@ export function mapValues<T>(
   return result;
 }
 
-export function isMatch<T>(a: T, b: T, ...omit: string[]): boolean {
+export function isEqual<T>(a: T, b: T, ...keysToIgnore: string[]): boolean {
   return (
     Object.entries(a)
-      .filter(e => !omit.includes(e[0]))
+      .filter(e => !keysToIgnore.includes(e[0]))
       .toString() ===
     Object.entries(b)
-      .filter(e => !omit.includes(e[0]))
+      .filter(e => !keysToIgnore.includes(e[0]))
       .toString()
   );
 }

--- a/packages/core/src/utils/primitives.ts
+++ b/packages/core/src/utils/primitives.ts
@@ -39,6 +39,16 @@ export function mapValues<T>(
   return result;
 }
 
+export function isMatch<T>(a: T, b: T, ...omit: string[]): boolean {
+  return (
+    Object.entries(a)
+      .filter(e => !omit.includes(e[0]))
+      .toString() ===
+    Object.entries(b)
+      .filter(e => !omit.includes(e[0]))
+      .toString()
+  );
+}
 export function isNumber(x?: unknown): x is number {
   return x === Number(x);
 }

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -151,10 +151,10 @@ describe('utils', () => {
       });
     });
 
-    it('isMatch', () => {
-      expect(utils.isMatch({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
-      expect(utils.isMatch({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 })).toBe(false);
-      expect(utils.isMatch({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 }, 'c')).toBe(true);
+    it('isEqual', () => {
+      expect(utils.isEqual({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+      expect(utils.isEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 })).toBe(false);
+      expect(utils.isEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 }, 'c')).toBe(true);
     });
 
     it('memoize', () => {

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -151,6 +151,12 @@ describe('utils', () => {
       });
     });
 
+    it('isMatch', () => {
+      expect(utils.isMatch({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+      expect(utils.isMatch({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 })).toBe(false);
+      expect(utils.isMatch({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 }, 'c')).toBe(true);
+    });
+
     it('memoize', () => {
       const md5Cached = utils.memoize(utils.md5);
       const fnvCached = utils.memoize(utils.fnv);


### PR DESCRIPTION
Check the upload activity when purging.
Each time the upload is accessed, the expiration is delayed.
To enable, set `expiration.rolling` to `true` .

```ts
const storage = new DiskStorage({
  directory: 'upload',
  expiration: { maxAge: '1h', purgeInterval: '30min', rolling: true },
});
```
https://github.com/Chocobozzz/PeerTube/issues/4907