### PR TITLE
refactor: host headers handling

### DIFF
--- a/packages/core/src/handlers/multipart.ts
+++ b/packages/core/src/handlers/multipart.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import * as multiparty from 'multiparty';
-import { UploadxFile, FileInit } from '../storages';
+import { FileInit, UploadxFile } from '../storages';
 import { setHeaders } from '../utils';
 import { BaseHandler, UploadxOptions } from './base-handler';
 

--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -24,7 +24,7 @@ const generateFileId = (file: File): string => {
 export interface FileInit {
   contentType?: string;
   originalName?: string;
-  metadata?: Metadata;
+  metadata: Metadata;
   size?: number | string;
   userId?: string;
 }

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -82,11 +82,17 @@ export function setHeaders(res: http.ServerResponse, headers: Headers = {}): voi
 }
 
 export function getBaseUrl(req: http.IncomingMessage): string {
-  const proto = extractProto(req);
-  const host = getHeader(req, 'host') || getHeader(req, 'x-forwarded-host');
+  const host = extractHost(req);
   if (!host) return '';
+  const proto = extractProto(req);
   if (!proto) return `//${host}`;
   return `${proto}://${host}`;
+}
+
+export function extractHost(
+  req: http.IncomingMessage & { host?: string; hostname?: string }
+): string {
+  return req.host || req.hostname || getHeader(req, 'host');
 }
 
 export function extractProto(req: http.IncomingMessage): string {

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -141,7 +141,7 @@ describe('utils', () => {
     });
 
     it('getBaseUrl(no-proto)', () => {
-      req.headers = { 'x-forwarded-host': 'example' };
+      req.headers = { host: 'example' };
       expect(utils.getBaseUrl(req)).toBe('//example');
     });
 


### PR DESCRIPTION
Support 'X-Forwarded-Host' header if express/fastify 'trust proxy' .