### PR TITLE
refactor: dot not use express v4 deprecated req.host

### DIFF
--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -123,7 +123,8 @@ export function getBaseUrl(req: http.IncomingMessage): string {
 export function extractHost(
   req: http.IncomingMessage & { host?: string; hostname?: string }
 ): string {
-  return req.host || req.hostname || getHeader(req, 'host');
+  // return req.host || req.hostname || getHeader(req, 'host'); // this is for express v5 / fastify
+  return getHeader(req, 'host');
 }
 
 /**


### PR DESCRIPTION
undo #558 because `req.host` is deprecated in Express v4