### PR TITLE
feat: file/range checksum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,22 +54,23 @@ Please navigate to the [examples](examples) for more.
 
 Some available options: :
 
-| option                |         type         |  default value   | description                                                  |
-| :-------------------- | :------------------: | :--------------: | ------------------------------------------------------------ |
-| `directory`           |       `string`       |    `"files"`     | _DiskStorage upload directory_                               |
-| `bucket`              |       `string`       | `"node-uploadx"` | _Storage bucket_                                             |
-| `path`                |       `string`       |    `"/files"`    | _Node http base path_                                        |
-| `allowMIME`           |      `string[]`      |    `["*\*"]`     | _Allowed MIME types_                                         |
-| `maxUploadSize`       |   `string\|number`   |     `"5TB"`      | _File size limit_                                            |
-| `metaStorage`         |    `MetaStorage`     |                  | _Provide custom meta storage_                                |
-| `metaStorageConfig`   | `MetaStorageOptions` |                  | _Configure metafiles storage_                                |
-| `maxMetadataSize`     |   `string\|number`   |     `"4MB"`      | _Metadata size limit_                                        |
-| `validation`          |     `Validation`     |                  | _Upload validation options_                                  |
-| `useRelativeLocation` |      `boolean`       |     `false`      | _Use relative urls_                                          |
-| `filename`            |      `Function`      |                  | _File naming function_                                       |
-| `userIdentifier`      |   `UserIdentifier`   |                  | _Get user identity_                                          |
-| `onComplete`          |     `OnComplete`     |                  | _On upload complete callback_                                |
-| `expiration`          | `ExpirationOptions`  |                  | _Configuring the cleanup of abandoned and completed uploads_ |
+| option                |           type           |  default value   | description                                                  |
+| :-------------------- | :----------------------: | :--------------: | ------------------------------------------------------------ |
+| `directory`           |         `string`         |    `"files"`     | _DiskStorage upload directory_                               |
+| `bucket`              |         `string`         | `"node-uploadx"` | _Storage bucket_                                             |
+| `path`                |         `string`         |    `"/files"`    | _Node http base path_                                        |
+| `allowMIME`           |        `string[]`        |    `["*\*"]`     | _Allowed MIME types_                                         |
+| `maxUploadSize`       |     `string\|number`     |     `"5TB"`      | _File size limit_                                            |
+| `metaStorage`         |      `MetaStorage`       |                  | _Provide custom meta storage_                                |
+| `metaStorageConfig`   |   `MetaStorageOptions`   |                  | _Configure metafiles storage_                                |
+| `maxMetadataSize`     |     `string\|number`     |     `"4MB"`      | _Metadata size limit_                                        |
+| `validation`          |       `Validation`       |                  | _Upload validation options_                                  |
+| `useRelativeLocation` |        `boolean`         |     `false`      | _Use relative urls_                                          |
+| `filename`            |        `Function`        |                  | _File naming function_                                       |
+| `userIdentifier`      |     `UserIdentifier`     |                  | _Get user identity_                                          |
+| `onComplete`          |       `OnComplete`       |                  | _On upload complete callback_                                |
+| `expiration`          |   `ExpirationOptions`    |                  | _Configuring the cleanup of abandoned and completed uploads_ |
+| `checksum`            | `boolean\|"md5"\|"sha1"` |                  | _Enable/disable file/range checksum calculation_             |
 
 ## Contributing
 

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -1,18 +1,13 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { DiskFile, uploadx } from '@uploadx/core';
 import * as express from 'express';
 
 const PORT = process.env.PORT || 3002;
-type UserInfo = { user?: { id: string; email: string } };
+type UserInfo = { user: { id: string; email: string } };
 
 const app = express();
 
-const auth = (
-  req: express.Request & UserInfo,
-  res: express.Response,
-  next: express.NextFunction
-) => {
-  req.user = { id: '92be348f', email: 'user@example.com' };
+const auth = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  (req as express.Request & UserInfo).user = { id: '92be348f', email: 'user@example.com' };
   next();
 };
 
@@ -27,7 +22,8 @@ app.use(
   uploadx.upload({
     directory: 'upload',
     expiration: { maxAge: '1h', purgeInterval: '10min' },
-    userIdentifier: (req: express.Request & UserInfo) => `${req.user!.id}-${req.user!.email}`
+    userIdentifier: (req: express.Request & UserInfo) => `${req.user.id}-${req.user.email}`,
+    checksum: 'sha1'
   }),
   onComplete
 );

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -5,6 +5,7 @@ import {
   BaseStorage,
   DiskStorage,
   DiskStorageOptions,
+  DiskStorageWithChecksum,
   UploadList,
   UploadxEventType,
   UploadxFile,
@@ -81,10 +82,13 @@ export abstract class BaseHandler<TFile extends UploadxFile>
   constructor(config: UploadxOptions<TFile> = {}) {
     super();
     this.cors = new Cors();
-    this.storage =
-      'storage' in config
-        ? config.storage
-        : (new DiskStorage(config) as unknown as BaseStorage<TFile>);
+    if ('storage' in config) {
+      this.storage = config.storage;
+    } else {
+      this.storage = (config.checksum
+        ? new DiskStorageWithChecksum(config)
+        : new DiskStorage(config)) as unknown as BaseStorage<TFile>;
+    }
     if (config.userIdentifier) {
       this.getUserId = config.userIdentifier;
     }

--- a/packages/core/src/handlers/uploadx.ts
+++ b/packages/core/src/handlers/uploadx.ts
@@ -88,6 +88,8 @@ export class Uploadx<TFile extends UploadxFile> extends BaseHandler<TFile> {
   }
 
   buildHeaders(file: UploadxFile, headers: Headers = {}): Headers {
+    if (file.md5) headers['X-Range-MD5'] = file.md5;
+    if (file.sha1) headers['X-Range-SHA1'] = file.sha1;
     if (file.expiredAt) headers['X-Upload-Expires'] = new Date(file.expiredAt).toISOString();
     return headers;
   }

--- a/packages/core/src/storages/disk-storage-with-checksum.ts
+++ b/packages/core/src/storages/disk-storage-with-checksum.ts
@@ -1,0 +1,99 @@
+import { FilePart, FileQuery, getFileStatus, hasContent, partMatch, updateSize } from './file';
+import {
+  ensureFile,
+  ERRORS,
+  fail,
+  getWriteStream,
+  hashes,
+  removeFile,
+  streamChecksum,
+  streamLength,
+  truncateFile
+} from '../utils';
+import { DiskFile, DiskStorage, DiskStorageOptions } from './disk-storage';
+
+/**
+ *  Additionally calculates checksum of the file/range
+ */
+export class DiskStorageWithChecksum extends DiskStorage {
+  constructor(config: DiskStorageOptions) {
+    super(config);
+    hashes.algorithm = config.checksum === 'sha1' ? 'sha1' : 'md5';
+  }
+
+  async delete({ id }: FileQuery): Promise<DiskFile[]> {
+    try {
+      const file = await this.getMeta(id);
+      const path = this.getFilePath(file.name);
+      hashes.delete(path);
+      await removeFile(path);
+      await this.deleteMeta(id);
+      return [{ ...file, status: 'deleted' }];
+    } catch {}
+    return [{ id } as DiskFile];
+  }
+
+  async write(part: FilePart | FileQuery): Promise<DiskFile> {
+    const file = await this.getMeta(part.id);
+    await this.checkIfExpired(file);
+    if (file.status === 'completed') return file;
+    if (part.size) updateSize(file, part.size);
+    if (!partMatch(part, file)) return fail(ERRORS.FILE_CONFLICT);
+    const path = this.getFilePath(file.name);
+    try {
+      file.bytesWritten = (part as FilePart).start || (await ensureFile(path));
+      await hashes.init(path);
+      if (hasContent(part)) {
+        if (this.isUnsupportedChecksum(part.checksumAlgorithm)) {
+          return fail(ERRORS.UNSUPPORTED_CHECKSUM_ALGORITHM);
+        }
+        const [bytesWritten, errorCode] = await this._write({ ...part, ...file });
+        if (errorCode) {
+          await truncateFile(path, file.bytesWritten);
+          return fail(errorCode);
+        }
+        if (!bytesWritten) {
+          await hashes.updateFromFs(path, file.bytesWritten);
+        }
+        file.bytesWritten = bytesWritten;
+      }
+      file.status = getFileStatus(file);
+      file[hashes.algorithm] = hashes.hex(path);
+      file.status === 'completed' && hashes.delete(path);
+      await this.saveMeta(file);
+      return file;
+    } catch (err) {
+      await hashes.updateFromFs(path, file.bytesWritten);
+      return fail(ERRORS.FILE_ERROR, err);
+    }
+  }
+
+  protected _write(part: FilePart & DiskFile): Promise<[number, ERRORS?]> {
+    return new Promise((resolve, reject) => {
+      const path = this.getFilePath(part.name);
+      const dest = getWriteStream(path, part.start);
+      const lengthChecker = streamLength(part.contentLength || part.size - part.start);
+      const checksumChecker = streamChecksum(part.checksum, part.checksumAlgorithm);
+      const digester = hashes.digester(path);
+      const keepPartial = !part.checksum;
+      const failWithCode = (code?: ERRORS): void => {
+        digester.reset();
+        dest.close();
+        resolve([NaN, code]);
+      };
+      lengthChecker.on('error', () => failWithCode(ERRORS.FILE_CONFLICT));
+      checksumChecker.on('error', () => failWithCode(ERRORS.CHECKSUM_MISMATCH));
+      part.body.on('aborted', () => failWithCode(keepPartial ? undefined : ERRORS.REQUEST_ABORTED));
+      part.body
+        .pipe(lengthChecker)
+        .pipe(checksumChecker)
+        .pipe(digester)
+        .pipe(dest)
+        .on('error', (err: Error) => {
+          digester.reset();
+          reject(err);
+        })
+        .on('finish', () => resolve([part.start + dest.bytesWritten]));
+    });
+  }
+}

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -45,6 +45,11 @@ export type DiskStorageOptions = BaseStorageOptions<DiskFile> & {
    * ```
    */
   metaStorageConfig?: LocalMetaStorageOptions;
+  /**
+   * Enable/disable file/range checksum calculation
+   * @experimental
+   */
+  checksum?: boolean | 'md5' | 'sha1';
 };
 
 /**
@@ -77,6 +82,8 @@ export class DiskStorage extends BaseStorage<DiskFile> {
 
   async create(req: http.IncomingMessage, fileInit: FileInit): Promise<DiskFile> {
     const file = new DiskFile(fileInit);
+    const existing = await this.getMeta(file.id).catch(() => null);
+    if (existing?.status === 'completed') return existing;
     file.name = this.namingFunction(file, req);
     file.size = Number.isNaN(file.size) ? this.maxUploadSize : file.size;
     await this.validate(file);
@@ -95,20 +102,19 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     if (!partMatch(part, file)) return fail(ERRORS.FILE_CONFLICT);
     const path = this.getFilePath(file.name);
     try {
+      file.bytesWritten = (part as FilePart).start || (await ensureFile(path));
       if (hasContent(part)) {
         if (this.isUnsupportedChecksum(part.checksumAlgorithm)) {
           return fail(ERRORS.UNSUPPORTED_CHECKSUM_ALGORITHM);
         }
-        const [bytesWritten, errorCode] = await this._write({ ...file, ...part });
+        const [bytesWritten, errorCode] = await this._write({ ...part, ...file });
         if (errorCode) {
-          await truncateFile(path, part.start);
+          await truncateFile(path, file.bytesWritten);
           return fail(errorCode);
         }
         file.bytesWritten = bytesWritten;
         file.status = getFileStatus(file);
         await this.saveMeta(file);
-      } else {
-        file.bytesWritten = await ensureFile(path);
       }
       return file;
     } catch (err) {
@@ -133,7 +139,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     return join(this.directory, filename);
   }
 
-  protected _write(part: FilePart & File): Promise<[number, ERRORS?]> {
+  protected _write(part: FilePart & DiskFile): Promise<[number, ERRORS?]> {
     return new Promise((resolve, reject) => {
       const dest = getWriteStream(this.getFilePath(part.name), part.start);
       const lengthChecker = streamLength(part.contentLength || part.size - part.start);
@@ -151,9 +157,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
         .pipe(checksumChecker)
         .pipe(dest)
         .on('error', reject)
-        .on('finish', () => {
-          return resolve([part.start + dest.bytesWritten]);
-        });
+        .on('finish', () => resolve([part.start + dest.bytesWritten]));
     });
   }
 

--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -43,6 +43,8 @@ export class File implements FileInit {
   userId?;
   expiredAt?: string | Date | number;
   createdAt?: string | Date | number;
+  md5?: string;
+  sha1?: string;
 
   constructor({ metadata = {}, originalName, contentType, size, userId }: FileInit) {
     this.metadata = metadata;

--- a/packages/core/src/storages/index.ts
+++ b/packages/core/src/storages/index.ts
@@ -1,5 +1,6 @@
 export * from './disk-storage';
+export * from './disk-storage-with-checksum';
 export * from './file';
-export * from './storage';
 export * from './local-meta-storage';
 export * from './meta-storage';
+export * from './storage';

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -164,7 +164,7 @@ export abstract class BaseStorage<TFile extends File> {
     this.updateTimestamps(file);
     const prev = { ...this.cache.get(file.id) };
     this.cache.set(file.id, file);
-    return isEqual(prev, file, 'bytesWritten', 'expiredAt')
+    return isEqual(prev, file, 'bytesWritten', 'expiredAt', 'md5', 'sha1')
       ? this.meta.touch(file.id, file)
       : this.meta.save(file.id, file);
   }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -5,4 +5,5 @@ export * from './http';
 export * from './logger';
 export * from './pipes';
 export * from './primitives';
+export * from './range-checksum';
 export * from './validator';

--- a/packages/core/src/utils/range-checksum.ts
+++ b/packages/core/src/utils/range-checksum.ts
@@ -1,0 +1,72 @@
+import { Transform } from 'stream';
+import { BinaryToTextEncoding, createHash, Hash } from 'crypto';
+import { Cache } from './cache';
+import { createReadStream } from 'fs';
+
+export class RangeChecksum extends Transform {
+  hash: Hash;
+  readonly _hash: Hash;
+
+  constructor(readonly path: string) {
+    super();
+    this.hash = hashes.get(path) || createHash(hashes.algorithm);
+    this._hash = this.hash.copy();
+  }
+
+  reset(): void {
+    hashes.set(this.path, this._hash);
+  }
+
+  digest(encoding: BinaryToTextEncoding = 'hex'): string {
+    return this.hash.copy().digest(encoding);
+  }
+
+  _transform(chunk: Buffer, encoding: string, done: () => void): void {
+    this.push(chunk);
+    this.hash.update(chunk);
+    done();
+  }
+
+  _flush(cb: (err?: Error) => void): void {
+    cb();
+  }
+}
+
+export class RangeHasher extends Cache<Hash> {
+  public algorithm: 'sha1' | 'md5' = 'sha1';
+
+  hex(path: string): string {
+    return this.get(path)?.copy().digest('hex') || '';
+  }
+
+  base64(path: string): string {
+    return this.get(path)?.copy().digest('base64') || '';
+  }
+
+  async init(path: string, start = 0): Promise<Hash> {
+    return this.get(path)?.copy() || this.updateFromFs(path, start);
+  }
+
+  digester(path: string): RangeChecksum {
+    return new RangeChecksum(path);
+  }
+
+  async updateFromFs(path: string, start = 0, initial?: Hash): Promise<Hash> {
+    const hash = await this._fromFs(path, start, initial);
+    return this.set(path, hash);
+  }
+
+  private _fromFs(path: string, start = 0, initial?: Hash): Promise<Hash> {
+    return new Promise((resolve, reject) => {
+      const digester = this.digester(path);
+      initial && (digester.hash = initial);
+      createReadStream(path, { start })
+        .on('error', reject)
+        .on('end', () => resolve(digester.hash))
+        .pipe(digester)
+        .resume();
+    });
+  }
+}
+
+export const hashes = new RangeHasher();

--- a/test/__snapshots__/disk-storage-with-checksum.spec.ts.snap
+++ b/test/__snapshots__/disk-storage-with-checksum.spec.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DiskStorageWithChecksum should support checksum resume from fs 1`] = `
+Object {
+  "bytesWritten": 10,
+  "contentType": "video/mp4",
+  "createdAt": "2022-02-02T00:00:00.000Z",
+  "expiredAt": "2022-02-02T01:00:00.000Z",
+  "id": "f7d13faa74e2475f-e8fed598250d10ea-7f59007b4b7cf67-120941ca7dc37b78",
+  "metadata": Object {
+    "custom": "",
+    "lastModified": 1635398061454,
+    "mimeType": "video/mp4",
+    "name": "testfile.mp4",
+    "sha1": "ZAPAntzKARqtb+j3B529GAOf3kI=",
+    "size": 64,
+  },
+  "name": "userId/testfile.mp4",
+  "originalName": "testfile.mp4",
+  "sha1": "87acec17cd9dcd20a716cc2cf67417b71c8a7016",
+  "size": 64,
+  "status": "part",
+  "userId": "userId",
+}
+`;

--- a/test/disk-storage-with-checksum.spec.ts
+++ b/test/disk-storage-with-checksum.spec.ts
@@ -1,0 +1,24 @@
+import { DiskStorageWithChecksum } from '../packages/core/src';
+import { authRequest, metafile, storageOptions } from './shared';
+import { Readable } from 'stream';
+
+const directory = 'ds-test';
+
+jest.mock('fs/promises');
+jest.mock('fs');
+
+describe('DiskStorageWithChecksum', () => {
+  jest.useFakeTimers({ doNotFake: ['setTimeout'] }).setSystemTime(new Date('2022-02-02'));
+  const options = { ...storageOptions, directory, checksum: 'sha1' as const };
+  const req = authRequest();
+
+  it('should support checksum resume from fs', async () => {
+    let storage = new DiskStorageWithChecksum(options);
+    let diskFile = await storage.create(req, { ...metafile });
+    await storage.write({ ...diskFile, start: 0, body: Readable.from('01234') });
+    storage = new DiskStorageWithChecksum(options);
+    diskFile = await storage.create(req, { ...metafile });
+    diskFile = await storage.write({ ...diskFile, start: 5, body: Readable.from('56789') });
+    expect(diskFile).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Added option `checksum` to enable sha1/md5 rolling hashes.
```ts
import { uploadx } from '@uploadx/core';
import * as express from 'express';

const app = express();
app.all(
  '/files',
  uploadx({
    directory: 'upload',
    checksum: 'sha1',
    onComplete: file => {
      console.log('File upload complete: %s, sha1: %s', file.originalName, file.sha1);
      return file;
    }
  })
);

app.listen(3002);
```

The checksum of the uploaded data is updated every chunk and sent to the client via the `x-range-sha1` or `x-range-md5` headers:
```
HTTP/1.1 308 Resume Incomplete

X-Range-SHA1: a8b78179bd6bd0132acc9c9bf14739f3f42d2839
Range: bytes=0-3145727
```