### PR TITLE
feat(core): option to customize error responses

### DIFF
--- a/examples/express-basic.ts
+++ b/examples/express-basic.ts
@@ -19,6 +19,6 @@ const uploads = uploadx({
   }
 });
 
-app.use('/uploads', uploads);
+app.use('/files', uploads);
 
 app.listen(PORT, () => console.log('listening on port:', PORT));

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -32,7 +32,15 @@ app.use(
     directory: 'upload',
     expiration: { maxAge: '1h', purgeInterval: '10min' },
     userIdentifier: (req: AuthRequest) => (req.user ? `${req.user.id}-${req.user.email}` : ''),
-    logger
+    logger,
+    onError: ({ statusCode, body }) => {
+      const errors = [{ status: statusCode, title: body?.code, detail: body?.message }];
+      return {
+        statusCode,
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: { errors }
+      };
+    }
   }),
   onComplete
 );

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -1,4 +1,4 @@
-import { logger, Logger } from '../utils';
+import { HttpError, logger } from '../utils';
 import { File } from './file';
 import { BaseStorageOptions } from './storage';
 
@@ -9,6 +9,9 @@ export class ConfigHandler {
     filename: ({ id }: File): string => id,
     useRelativeLocation: false,
     onComplete: () => null,
+    onError: ({ statusCode, body, headers }: HttpError) => {
+      return { statusCode, body: { error: body }, headers };
+    },
     path: '/files',
     validation: {},
     maxMetadataSize: '4MB',
@@ -24,10 +27,4 @@ export class ConfigHandler {
   get<T extends File>(): Required<BaseStorageOptions<T>> {
     return this._config as unknown as Required<BaseStorageOptions<T>>;
   }
-
-  getLogger(): Logger {
-    return this._config.logger;
-  }
 }
-
-export const configHandler = new ConfigHandler();

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -2,7 +2,7 @@ import { logger, Logger } from '../utils';
 import { File } from './file';
 import { BaseStorageOptions } from './storage';
 
-class ConfigHandler {
+export class ConfigHandler {
   static defaults = {
     allowMIME: ['*/*'],
     maxUploadSize: '5TB',

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -61,7 +61,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     if (config.metaStorage) {
       this.meta = config.metaStorage;
     } else {
-      const metaConfig = { ...config, ...(config.metaStorageConfig || {}) };
+      const metaConfig = { ...config, ...(config.metaStorageConfig || {}), logger: this.logger };
       this.meta = new LocalMetaStorage(metaConfig);
     }
     this.accessCheck().catch(err => {

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -1,5 +1,5 @@
 import { FileName } from './file';
-import { configHandler } from './config';
+import { logger, Logger } from '../utils';
 
 /** @experimental */
 export interface UploadListEntry {
@@ -19,6 +19,7 @@ export interface UploadList {
 export interface MetaStorageOptions {
   prefix?: string;
   suffix?: string;
+  logger?: Logger;
 }
 
 /**
@@ -27,13 +28,14 @@ export interface MetaStorageOptions {
 export class MetaStorage<T> {
   prefix = '';
   suffix = '';
-  logger = configHandler.getLogger();
+  logger: Logger;
 
   constructor(config?: MetaStorageOptions) {
     this.prefix = config?.prefix || '';
     this.suffix = config?.suffix || METAFILE_EXTNAME;
     this.prefix && FileName.INVALID_PREFIXES.push(this.prefix);
     this.suffix && FileName.INVALID_SUFFIXES.push(this.suffix);
+    this.logger = config?.logger || logger;
   }
 
   /**

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -1,6 +1,5 @@
 import * as bytes from 'bytes';
 import * as http from 'http';
-
 import {
   Cache,
   ErrorMap,
@@ -8,12 +7,14 @@ import {
   ERRORS,
   fail,
   HttpError,
+  HttpErrorBody,
   isEqual,
   Locker,
   Logger,
   LogLevel,
   toMilliseconds,
   typeis,
+  UploadxResponse,
   Validation,
   Validator,
   ValidatorConfig
@@ -28,6 +29,8 @@ export type UserIdentifier = (req: any, res: any) => string;
 export type OnComplete<TFile extends File, TResponseBody = any> = (
   file: TFile
 ) => Promise<TResponseBody> | TResponseBody;
+
+export type OnError<TResponseBody = HttpErrorBody> = (error: HttpError<TResponseBody>) => any;
 
 export type PurgeList = UploadList & { maxAgeMs: number };
 
@@ -59,6 +62,7 @@ export interface BaseStorageOptions<T extends File> {
   useRelativeLocation?: boolean;
   /** Completed callback */
   onComplete?: OnComplete<T>;
+  onError?: OnError;
   /** Node http base path */
   path?: string;
   /** Upload validation options */
@@ -97,6 +101,7 @@ export const locker = new Locker(1000, LOCK_TIMEOUT);
 
 export abstract class BaseStorage<TFile extends File> {
   onComplete: (file: TFile) => Promise<any> | any;
+  onError: (err: HttpError) => UploadxResponse;
   maxUploadSize: number;
   maxMetadataSize: number;
   path: string;
@@ -114,6 +119,7 @@ export abstract class BaseStorage<TFile extends File> {
     const opts = configHandler.set(config);
     this.path = opts.path;
     this.onComplete = opts.onComplete;
+    this.onError = opts.onError;
     this.namingFunction = opts.filename;
     this.maxUploadSize = bytes.parse(opts.maxUploadSize);
     this.maxMetadataSize = bytes.parse(opts.maxMetadataSize);

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -21,7 +21,7 @@ import {
 import { File, FileInit, FileName, FilePart, FileQuery, isExpired, updateMetadata } from './file';
 import { MetaStorage, UploadList } from './meta-storage';
 import { setInterval } from 'timers';
-import { configHandler } from './config';
+import { ConfigHandler } from './config';
 
 export type UserIdentifier = (req: any, res: any) => string;
 
@@ -110,6 +110,7 @@ export abstract class BaseStorage<TFile extends File> {
   abstract meta: MetaStorage<TFile>;
 
   protected constructor(public config: BaseStorageOptions<TFile>) {
+    const configHandler = new ConfigHandler();
     const opts = configHandler.set(config);
     this.path = opts.path;
     this.onComplete = opts.onComplete;

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -108,7 +108,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
     if (config.metaStorage) {
       this.meta = config.metaStorage;
     } else {
-      const metaConfig = { ...config, ...(config.metaStorageConfig || {}) };
+      const metaConfig = { ...config, ...(config.metaStorageConfig || {}), logger: this.logger };
       this.meta =
         'directory' in metaConfig
           ? new LocalMetaStorage(metaConfig)

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -106,7 +106,7 @@ export class S3Storage extends BaseStorage<S3File> {
     if (config.metaStorage) {
       this.meta = config.metaStorage;
     } else {
-      const metaConfig = { ...config, ...(config.metaStorageConfig || {}) };
+      const metaConfig = { ...config, ...(config.metaStorageConfig || {}), logger: this.logger };
       this.meta =
         'directory' in metaConfig
           ? new LocalMetaStorage(metaConfig)

--- a/test/shared/uploader.ts
+++ b/test/shared/uploader.ts
@@ -1,6 +1,7 @@
 import {
   BaseHandler,
   BaseStorage,
+  BaseStorageOptions,
   File,
   FileInit,
   FilePart,
@@ -14,7 +15,7 @@ export class TestStorage extends BaseStorage<File> {
   path = '/files';
   isReady = true;
   meta = new MetaStorage<File>();
-  constructor(config = {}) {
+  constructor(config = {} as BaseStorageOptions<File>) {
     super(config);
   }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "baseUrl": "./",
     "rootDir": ".",
-    "outDir": "dist",
     "composite": true,
     "target": "es2019",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Added `onError` hook to options
```ts
app.use(
  '/upload',
  uploadx({
    directory: 'upload',
    onError: ({ statusCode, body }) => {
      const errors = [{ status: statusCode, title: body?.code, detail: body?.message }];
      return {
        statusCode,
        headers: { 'Content-Type': 'application/vnd.api+json' },
        body: { errors }
      };
    },
    onComplete: file => {
      console.log('File upload complete: ', file);
      return file;
    }
  })
);
```