### PR TITLE
refactor(s3): handle presigned uploads

### DIFF
--- a/examples/express-gcs.ts
+++ b/examples/express-gcs.ts
@@ -7,7 +7,7 @@ const app = express();
 
 const storage = new GCStorage({
   maxUploadSize: '1GB',
-  onComplete: ({ uri, id }) => {
+  onComplete: ({ uri = 'unknown', id }) => {
     console.log(`File upload complete, storage path: ${uri}`);
     // send gcs link to client
     return { id, link: uri };

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -74,6 +74,10 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     return super.normalizeError(err);
   }
 
+  accessCheck(): Promise<void> {
+    return accessCheck(this.directory);
+  }
+
   async create(req: http.IncomingMessage, fileInit: FileInit): Promise<DiskFile> {
     const file = new DiskFile(fileInit);
     file.name = this.namingFunction(file, req);
@@ -157,9 +161,5 @@ export class DiskStorage extends BaseStorage<DiskFile> {
           return resolve([part.start + dest.bytesWritten]);
         });
     });
-  }
-
-  private accessCheck(): Promise<void> {
-    return accessCheck(this.directory);
   }
 }

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -78,7 +78,7 @@ export interface GCStorageOptions extends BaseStorageOptions<GCSFile>, GoogleAut
 
 export class GCSFile extends File {
   GCSUploadURI?: string;
-  uri = '';
+  uri?: string;
 }
 
 /**
@@ -140,6 +140,10 @@ export class GCStorage extends BaseStorage<GCSFile> {
       };
     }
     return super.normalizeError(error);
+  }
+
+  accessCheck(): Promise<any> {
+    return this.authClient.request({ url: `${GCSConfig.storageAPI}/${this.bucket}` });
   }
 
   async create(req: http.IncomingMessage, config: FileInit): Promise<GCSFile> {
@@ -209,7 +213,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
   }
 
   protected async _write(part: Partial<FilePart> & GCSFile): Promise<number> {
-    const { size, uri, body } = part;
+    const { size, uri = '', body } = part;
     const contentRange = buildContentRange(part);
     const options: Record<string, any> = { method: 'PUT' };
     if (body?.on) {
@@ -245,8 +249,4 @@ export class GCStorage extends BaseStorage<GCSFile> {
   private _onComplete = (file: GCSFile): Promise<any> => {
     return this.deleteMeta(file.id);
   };
-
-  private accessCheck(): Promise<any> {
-    return this.authClient.request({ url: `${GCSConfig.storageAPI}/${this.bucket}` });
-  }
 }


### PR DESCRIPTION
Allows send patch request with empty body to complete/get presigned uploads