### PR TITLE
chore: env variable sets upload dir in examples

### DIFF
--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,5 +1,5 @@
 LOG_LEVEL=debug
-
+UPLOAD_DIR='upload'
 PORT=3002
 
 # Get this from https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?supportedpurview=project

--- a/examples/express-basic.ts
+++ b/examples/express-basic.ts
@@ -6,7 +6,7 @@ const PORT = process.env.PORT || 3002;
 const app = express();
 
 const uploads = uploadx({
-  directory: 'upload',
+  directory: process.env.UPLOAD_DIR || 'upload',
   maxUploadSize: '1GB',
   allowMIME: ['video/*', 'image/*'],
   useRelativeLocation: true,

--- a/examples/express-polling.ts
+++ b/examples/express-polling.ts
@@ -12,7 +12,7 @@ type Moving = { percent: number; status: 'moving' | 'error' | 'done' };
 
 const processes = {} as Record<string, Moving>;
 
-const uploadDirectory = 'upload';
+const uploadDirectory = process.env.UPLOAD_DIR || 'upload';
 const moveTo = 'files';
 
 const storage = new DiskStorage({ directory: uploadDirectory });

--- a/examples/express-tus.ts
+++ b/examples/express-tus.ts
@@ -4,10 +4,9 @@ import { DiskFile, DiskStorageOptions, tus } from '@uploadx/core';
 const PORT = process.env.PORT || 3002;
 
 const app = express();
-const uploadDirectory = 'upload';
 const opts: DiskStorageOptions = {
   allowMIME: ['image/*', 'video/*'],
-  directory: uploadDirectory
+  directory: process.env.UPLOAD_DIR || 'upload'
 };
 
 app.use('/files', tus.upload(opts), (req, res) => {

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -29,7 +29,7 @@ const onComplete: express.RequestHandler = (req, res, next) => {
 app.use(
   '/files',
   uploadx.upload({
-    directory: 'upload',
+    directory: process.env.UPLOAD_DIR || 'upload',
     expiration: { maxAge: '1h', purgeInterval: '10min' },
     userIdentifier: (req: AuthRequest) => (req.user ? `${req.user.id}-${req.user.email}` : ''),
     logger,

--- a/examples/fastify.ts
+++ b/examples/fastify.ts
@@ -9,7 +9,7 @@ const logger = pino({ level: process.env.LOG_LEVEL || 'info', name: 'uploadx' })
 const port = process.env.PORT || 3002;
 
 async function build() {
-  const uploadx = new Uploadx({ directory: 'upload', logger });
+  const uploadx = new Uploadx({ directory: process.env.UPLOAD_DIR || 'upload', logger });
   uploadx.on('completed', ({ name, originalName }) =>
     logger.info(`upload complete, path: ${join('files', name)}, original filename: ${originalName}`)
   );

--- a/examples/node-http-server.js
+++ b/examples/node-http-server.js
@@ -6,7 +6,7 @@ const { DiskStorage, Uploadx } = require('@uploadx/core');
 const PORT = process.env.PORT || 3002;
 
 const storage = new DiskStorage({
-  directory: 'upload',
+  directory: process.env.UPLOAD_DIR || 'upload',
   path: '/files',
   maxUploadSize: '15GB',
   allowMIME: ['video/*', 'image/*']

--- a/examples/server.js
+++ b/examples/server.js
@@ -4,7 +4,7 @@ const cors = require('cors');
 
 const PORT = process.env.PORT || 3002;
 const opts = {
-  directory: 'upload',
+  directory: process.env.UPLOAD_DIR || 'upload',
   allowMIME: ['video/*', 'image/*'],
   maxUploadSize: process.env.MAX_UPLOAD_SIZE || '2GB',
   expiration: { maxAge: process.env.MAX_AGE || '1h', purgeInterval: '10min' },

--- a/examples/validation.ts
+++ b/examples/validation.ts
@@ -22,7 +22,7 @@ const onComplete: OnComplete<DiskFile, UploadxResponse<OnCompleteBody>> = file =
 };
 
 const storage = new DiskStorage({
-  directory: 'upload',
+  directory: process.env.UPLOAD_DIR || 'upload',
   onComplete,
   expiration: { maxAge: '1h', purgeInterval: '10min' },
   validation: {


### PR DESCRIPTION
Support for the `UPLOAD_DIR` environment variable to set the upload directory in the examples.