### PR TITLE
fix(types): ServerResponse type

### DIFF
--- a/packages/core/src/types/http.ts
+++ b/packages/core/src/types/http.ts
@@ -4,9 +4,7 @@ export type IncomingMessage = http.IncomingMessage & {
   originalUrl?: string;
 };
 
-export type ServerResponse = http.ServerResponse & {
-  req?: http.IncomingMessage;
-};
+export type ServerResponse = http.ServerResponse;
 
 export interface IncomingMessageWithBody<T = any> extends http.IncomingMessage {
   body?: T;


### PR DESCRIPTION
The optional `req` is no longer needed in newer versions of NodeJS (v15.7.0+)