### PR TITLE
fix: saveMeta incorrectly called touch instead of save

### DIFF
--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -209,7 +209,10 @@ export abstract class BaseStorage<TFile extends File> {
   }
 
   /**
-   * Retrieves upload metadata
+   * Retrieves upload metadata.
+   *
+   * @remarks
+   * Returns a shallow copy — nested user metadata objects remain shared with the cache.
    */
   async getMeta(id: string): Promise<TFile> {
     let file = this.cache.get(id);
@@ -221,7 +224,7 @@ export abstract class BaseStorage<TFile extends File> {
         return fail(ERRORS.FILE_NOT_FOUND);
       }
     }
-    return { ...file };
+    return { ...file, metadata: { ...file.metadata } };
   }
 
   checkIfExpired(file: TFile): Promise<TFile> {

--- a/test/shared/config.ts
+++ b/test/shared/config.ts
@@ -47,7 +47,7 @@ export const testfile = {
 export const metafile = {
   bytesWritten: null as number | null,
   name: 'userId/testfile.mp4',
-  metadata,
+  metadata: { ...metadata },
   originalName: 'testfile.mp4',
   contentType,
   size,

--- a/test/storage.spec.ts
+++ b/test/storage.spec.ts
@@ -1,7 +1,18 @@
+import type { File } from '../packages/core/src';
 import { metafile, TestStorage } from './shared';
 
 describe('BaseStorage', () => {
-  let storage;
+  let storage: TestStorage;
+
+  async function createFile(overrides: Partial<File> = {}): Promise<File> {
+    const init = {
+      ...metafile,
+      metadata: { ...metafile.metadata },
+      ...overrides
+    } as File;
+    const created = await storage.create({}, init);
+    return storage.saveMeta(created);
+  }
 
   it('should share logger', () => {
     storage = new TestStorage();
@@ -58,5 +69,87 @@ describe('BaseStorage', () => {
     storage.logger.debug('some', 'value');
     expect(consoleDebugMock).toHaveBeenCalledWith('some', 'value');
     consoleDebugMock.mockRestore();
+  });
+
+  it('should save meta and update cache', async () => {
+    storage = new TestStorage();
+    const created = await createFile({ bytesWritten: 100 });
+    const result = await storage.saveMeta({
+      ...created,
+      bytesWritten: 200,
+      status: 'part' as const
+    });
+
+    expect(result.bytesWritten).toBe(200);
+    expect(storage.cache.get(metafile.id)!.bytesWritten).toBe(200);
+  });
+
+  it('should update user metadata', async () => {
+    storage = new TestStorage();
+    await createFile();
+
+    const result = await storage.update(
+      { id: metafile.id },
+      {
+        metadata: { name: 'newname.mp4', customKey: 'customValue', tags: ['tag1', 'tag2', 'tag3'] }
+      }
+    );
+
+    expect(result.metadata.name).toBe('newname.mp4');
+    expect(result.metadata.customKey).toBe('customValue');
+    expect(result.metadata.tags).toEqual(['tag1', 'tag2', 'tag3']);
+    expect(storage.cache.get(metafile.id)!.metadata.name).toBe('newname.mp4');
+  });
+
+  it('should call meta.save (not touch) when user metadata changes', async () => {
+    storage = new TestStorage();
+    await createFile();
+
+    const saveSpy = jest.spyOn(storage.meta, 'save');
+    const touchSpy = jest.spyOn(storage.meta, 'touch');
+
+    await storage.update(
+      { id: metafile.id },
+      {
+        metadata: { name: 'newname.mp4', customKey: 'customValue', tags: ['tag1', 'tag2', 'tag3'] }
+      }
+    );
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(touchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should call meta.save when user metadata deep changed', async () => {
+    storage = new TestStorage();
+    await createFile({
+      metadata: { customKey: 'customValue', tags: ['tag1', 'tag2', 'tag3'] }
+    });
+
+    const saveSpy = jest.spyOn(storage.meta, 'save');
+    const touchSpy = jest.spyOn(storage.meta, 'touch');
+
+    await storage.update(
+      { id: metafile.id },
+      {
+        metadata: { customKey: 'customValue', tags: ['tag1', 'tag2', 'tag4'] }
+      }
+    );
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(touchSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call meta.touch when only bytesWritten or expiredAt change', async () => {
+    storage = new TestStorage();
+    await createFile({ bytesWritten: 100 });
+
+    const saveSpy = jest.spyOn(storage.meta, 'save');
+    const touchSpy = jest.spyOn(storage.meta, 'touch');
+
+    const cached = storage.cache.get(metafile.id)!;
+    await storage.saveMeta({ ...cached, bytesWritten: 200, expiredAt: '2099-01-01T00:00:00.000Z' });
+
+    expect(touchSpy).toHaveBeenCalledTimes(1);
+    expect(saveSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
saveMeta called touch instead of save when metadata was mutated via getMeta.

Fixed by returning a shallow-copied metadata object from getMeta.
Added tests for save/touch/saveMeta behavior.