### PR TITLE
refactor(core): rename detail to cause

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,7 +64,7 @@ export default [
       '@typescript-eslint/no-this-alias': 'error',
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-require-imports': 'off',
-      '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
+      '@typescript-eslint/no-unused-vars': ['error', { args: 'none', varsIgnorePattern: '^_' }],
       '@typescript-eslint/prefer-function-type': 'error',
       '@typescript-eslint/prefer-namespace-keyword': 'error',
       '@typescript-eslint/promise-function-async': 'off',

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -32,12 +32,22 @@ app.use(
     expiration: { maxAge: '1h', purgeInterval: '10min' },
     userIdentifier: (req: AuthRequest) => (req.user ? `${req.user.id}-${req.user.email}` : ''),
     logger,
-    onError: ({ statusCode, body }) => {
-      const errors = [{ status: statusCode, title: body?.code, detail: body?.message }];
+    onError: (error: unknown) => {
+      const isDev = process.env.NODE_ENV === 'development';
+      const e = error as Record<string, unknown>;
+      const b = (e.body ?? e) as Record<string, unknown>;
+
+      const errorResponse = {
+        error: {
+          code: b.code || b.uploadxErrorCode || 'InternalError',
+          message: b.message || 'An unexpected error occurred',
+          ...(isDev && b.cause ? { debug: b.cause } : {})
+        }
+      };
+
       return {
-        statusCode,
-        headers: { 'Content-Type': 'application/vnd.api+json' },
-        body: { errors }
+        statusCode: Number(e.statusCode) || 500,
+        body: errorResponse
       };
     }
   }),

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -227,7 +227,7 @@ export abstract class BaseHandler<TFile extends UploadxFile>
    */
   sendError(res: ServerResponse, error: Error): void {
     const httpError = isUploadxError(error)
-      ? this._errorResponses[error.uploadxErrorCode]
+      ? { ...this._errorResponses[error.uploadxErrorCode], cause: error.cause }
       : isValidationError(error)
         ? error
         : this.storage.normalizeError(error);

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -177,15 +177,16 @@ export abstract class BaseHandler<TFile extends UploadxFile>
         return;
       })
       .catch((error: Error) => {
+        const keys = Object.getOwnPropertyNames(error) as (keyof Error)[];
         const err = pick(error, [
           'name',
-          ...(Object.getOwnPropertyNames(error) as (keyof Error)[])
+          ...(isUploadxError(error) ? keys.filter(k => k !== 'stack') : keys)
         ]) as UploadxError;
         const errorEvent = { ...err, request: pick(req, ['headers', 'method', 'url']) };
         this.listenerCount('error') && this.emit('error', errorEvent);
         this.logger.error('[error]: %O', errorEvent);
         if ('aborted' in req && req['aborted']) return;
-        return this.sendError(res, error);
+        return this.sendError(res, err);
       });
   };
 

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -12,8 +12,11 @@ export class ConfigHandler {
     onUpdate: (file: File) => file,
     onCreate: () => '',
     onDelete: () => '',
-    onError: ({ statusCode, body, headers }: HttpError) => {
-      return { statusCode, body: { error: body }, headers };
+    onError: ({ statusCode, body, headers, cause, ...rest }: HttpError) => {
+      const payload = (body || rest) as Record<string, unknown>;
+      const { cause: _c, ...noDetails } = payload;
+      void _c;
+      return { statusCode, body: { error: noDetails }, headers };
     },
     path: '/files',
     validation: {},

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -15,7 +15,6 @@ export class ConfigHandler {
     onError: ({ statusCode, body, headers, cause, ...rest }: HttpError) => {
       const payload = (body || rest) as Record<string, unknown>;
       const { cause: _c, ...noDetails } = payload;
-      void _c;
       return { statusCode, body: { error: noDetails }, headers };
     },
     path: '/files',

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -67,12 +67,12 @@ export const ErrorMap = E_.errors;
 
 export class UploadxError extends Error {
   uploadxErrorCode: ERRORS = ERRORS.UNKNOWN_ERROR;
-  detail?: unknown;
+  cause?: unknown;
 
-  constructor(uploadxErrorCode: ERRORS = ERRORS.UNKNOWN_ERROR, message?: string, detail?: unknown) {
+  constructor(uploadxErrorCode: ERRORS = ERRORS.UNKNOWN_ERROR, message?: string, cause?: unknown) {
     super(message || uploadxErrorCode);
     this.name = 'UploadxError';
-    this.detail = detail;
+    this.cause = cause;
     if (Object.values(ERRORS).includes(uploadxErrorCode)) {
       this.uploadxErrorCode = uploadxErrorCode;
     }
@@ -83,8 +83,8 @@ export function isUploadxError(err: unknown): err is UploadxError {
   return !!(err as UploadxError).uploadxErrorCode;
 }
 
-export function fail(uploadxErrorCode: ERRORS, detail: unknown = ''): Promise<never> {
-  return Promise.reject(new UploadxError(uploadxErrorCode, uploadxErrorCode, detail));
+export function fail(uploadxErrorCode: ERRORS, cause?: unknown): Promise<never> {
+  return Promise.reject(new UploadxError(uploadxErrorCode, uploadxErrorCode, cause));
 }
 
 export interface HttpErrorBody {
@@ -93,7 +93,7 @@ export interface HttpErrorBody {
   uploadxErrorCode?: string;
   name?: string;
   retryable?: boolean;
-  detail?: Record<string, any> | string;
+  cause?: Record<string, any> | string;
 }
 
 export interface HttpError<T = HttpErrorBody> extends UploadxResponse<T> {

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -63,7 +63,7 @@ class E_ {
   }
 }
 
-export const ErrorMap = E_.errors;
+export const ErrorMap: ErrorResponses<ERRORS> = E_.errors;
 
 export class UploadxError extends Error {
   uploadxErrorCode: ERRORS = ERRORS.UNKNOWN_ERROR;
@@ -80,11 +80,13 @@ export class UploadxError extends Error {
 }
 
 export function isUploadxError(err: unknown): err is UploadxError {
-  return !!(err as UploadxError).uploadxErrorCode;
+  return !!(err as UploadxError)?.uploadxErrorCode;
 }
 
 export function fail(uploadxErrorCode: ERRORS, cause?: unknown): Promise<never> {
-  return Promise.reject(new UploadxError(uploadxErrorCode, uploadxErrorCode, cause));
+  const entry = ErrorMap[uploadxErrorCode];
+  const message = (entry as { message?: string })?.message;
+  return Promise.reject(new UploadxError(uploadxErrorCode, message, cause));
 }
 
 export interface HttpErrorBody {

--- a/test/errors.spec.ts
+++ b/test/errors.spec.ts
@@ -1,0 +1,61 @@
+import {
+  ERRORS,
+  ErrorMap,
+  UploadxError,
+  fail,
+  isUploadxError
+} from '../packages/core/src/utils/errors';
+
+describe('errors', () => {
+  describe('ErrorMap', () => {
+    it('should contain all error codes', () => {
+      expect(Object.keys(ErrorMap)).toHaveLength(Object.keys(ERRORS).length);
+    });
+
+    it('should have correct error shape', () => {
+      const err = ErrorMap.BadRequest;
+      expect(err).toEqual({
+        code: 'BadRequest',
+        message: 'Bad request',
+        statusCode: 400
+      });
+    });
+  });
+
+  describe('UploadxError', () => {
+    it('should store cause', () => {
+      const cause = new Error('original');
+      const err = new UploadxError(ERRORS.BAD_REQUEST, 'msg', cause);
+      expect(err.cause).toBe(cause);
+    });
+  });
+
+  describe('isUploadxError', () => {
+    it('should return true for UploadxError instances', () => {
+      expect(isUploadxError(new UploadxError(ERRORS.BAD_REQUEST))).toBe(true);
+    });
+
+    it('should return false for non-UploadxError', () => {
+      expect(isUploadxError(new Error('test'))).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(isUploadxError(null)).toBe(false);
+    });
+  });
+
+  describe('fail', () => {
+    it('should reject with UploadxError', async () => {
+      await expect(fail(ERRORS.BAD_REQUEST)).rejects.toBeInstanceOf(UploadxError);
+    });
+
+    it('should use human-readable message', async () => {
+      await expect(fail(ERRORS.BAD_REQUEST)).rejects.toHaveProperty('message', 'Bad request');
+    });
+
+    it('should store cause', async () => {
+      const cause = 'test cause';
+      await expect(fail(ERRORS.BAD_REQUEST, cause)).rejects.toHaveProperty('cause', cause);
+    });
+  });
+});


### PR DESCRIPTION
Changes proposed in this pull request:
- Rename `detail` to `cause` in `UploadxError`, `fail()`, and `HttpErrorBody`
- Strip internal `cause` from default error response.


BREAKING CHANGE: `UploadxError.detail`, `HttpErrorBody.detail`, and `fail()` parameter renamed to `cause`.