### PR TITLE
refactor: migrate from BasicLogger to @logtape/logtape

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,15 @@ Some available options: :
 | `onDelete`            |      `OnDelete`      |                  | _Callback that is called when an upload is cancelled_        |
 | `onError`             |      `OnError`       |                  | _Customize error response_                                   |
 | `expiration`          | `ExpirationOptions`  |                  | _Configuring the cleanup of abandoned and completed uploads_ |
-| `logger`              |       `Logger`       |                  | _Custom logger injection_                                    |
 | `logLevel`            |      `LogLevel`      |     `"none"`     | _Set built-in logger severity level_                         |
 
-## Environment Variables
+## 📝 Logging
+
+The library uses [`@logtape/logtape`](https://logtape.org/) for structured logging. Set `logLevel` to enable it, or configure LogTape directly for advanced use cases.
+
+See [examples/express-logtape.ts](examples/express-logtape.ts) for a complete example.
+
+## 🔑 Environment Variables
 
 `UPLOADX_SECRET` - Secret for salting file/user IDs (set to random string in production).
 

--- a/examples/express-basic.ts
+++ b/examples/express-basic.ts
@@ -1,4 +1,4 @@
-import { LogLevel, uploadx } from '@uploadx/core';
+import { uploadx } from '@uploadx/core';
 import express from 'express';
 
 const PORT = process.env.PORT || 3002;
@@ -12,7 +12,6 @@ const uploads = uploadx({
   useRelativeLocation: true,
   filename: file => file.originalName,
   expiration: { maxAge: '1h', purgeInterval: '10min' },
-  logLevel: <LogLevel>process.env.LOG_LEVEL || 'info',
   onComplete: file => {
     console.log('File upload complete: ', file);
     return file;

--- a/examples/express-logtape.ts
+++ b/examples/express-logtape.ts
@@ -1,0 +1,42 @@
+import { configure, getConsoleSink, getLogger } from '@logtape/logtape';
+import { uploadx } from '@uploadx/core';
+import express from 'express';
+
+const PORT = process.env.PORT || 3002;
+const app = express();
+const appLogger = getLogger(['uploadx', 'app']);
+
+async function startApp() {
+  await configure({
+    sinks: {
+      console: getConsoleSink()
+    },
+    loggers: [
+      {
+        category: ['uploadx'],
+        lowestLevel: 'debug',
+        sinks: ['console']
+      },
+      {
+        category: ['logtape', 'meta'],
+        lowestLevel: 'warning',
+        sinks: ['console']
+      }
+    ]
+  });
+
+  const uploads = uploadx({
+    directory: process.env.UPLOAD_DIR || 'upload',
+    maxUploadSize: '1GB',
+    allowMIME: ['video/*', 'image/*'],
+    useRelativeLocation: true,
+    filename: file => file.originalName,
+    expiration: { maxAge: '1h', purgeInterval: '10min' }
+  });
+
+  app.use('/files', uploads);
+
+  app.listen(PORT, () => appLogger.info('listening on port: {port}', { port: PORT }));
+}
+
+startApp().catch((err: unknown) => appLogger.error('Server failed to start: {err}', { err }));

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -1,18 +1,13 @@
-import { uploadx } from '@uploadx/core';
+import { uploadx, getLogger } from '@uploadx/core';
 import express from 'express';
-import { createLogger, format, transports } from 'winston';
 
 type AuthRequest = express.Request & { user?: { id: string; email: string } };
 
 const PORT = process.env.PORT || 3002;
 
-const logger = createLogger({
-  format: format.combine(format.splat(), format.simple()),
-  transports: [new transports.Console()],
-  level: process.env.LOG_LEVEL || 'info'
-});
-
 const app = express();
+
+const appLogger = getLogger(['uploadx', 'server']);
 
 const auth = (req: AuthRequest, res: express.Response, next: express.NextFunction) => {
   req.user = { id: '92be348f', email: 'user@example.com' };
@@ -28,30 +23,17 @@ const onComplete: express.RequestHandler = (req, res, next) => {
 app.use(
   '/files',
   uploadx.upload({
+    maxUploadSize: '1GB',
     directory: process.env.UPLOAD_DIR || 'upload',
     expiration: { maxAge: '1h', purgeInterval: '10min' },
     userIdentifier: (req: AuthRequest) => (req.user ? `${req.user.id}-${req.user.email}` : ''),
-    logger,
-    onError: (error: unknown) => {
-      const isDev = process.env.NODE_ENV === 'development';
-      const e = error as Record<string, unknown>;
-      const b = (e.body ?? e) as Record<string, unknown>;
-
-      const errorResponse = {
-        error: {
-          code: b.code || b.uploadxErrorCode || 'InternalError',
-          message: b.message || 'An unexpected error occurred',
-          ...(isDev && b.cause ? { debug: b.cause } : {})
-        }
-      };
-
-      return {
-        statusCode: Number(e.statusCode) || 500,
-        body: errorResponse
-      };
+    logLevel: 'debug',
+    onComplete: file => {
+      appLogger.info(`File upload complete: ${file.name}`);
+      return file;
     }
   }),
   onComplete
 );
 
-app.listen(PORT, () => logger.info('listening on port: %d', PORT));
+app.listen(PORT, () => appLogger.info('listening on port: {PORT}', { PORT }));

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,6 +8,7 @@
     "express-polling": "tsnd -r tsconfig-paths/register -r dotenv/config express-polling",
     "gcs:direct": "tsnd -r tsconfig-paths/register -r dotenv/config gcs-direct",
     "gcs": "tsnd -r tsconfig-paths/register -r dotenv/config express-gcs",
+    "logtape": "tsnd -r tsconfig-paths/register -r dotenv/config express-logtape",
     "s3": "tsnd -r tsconfig-paths/register -r dotenv/config express-s3",
     "s3:direct": "tsnd -r tsconfig-paths/register -r dotenv/config s3-direct",
     "tus": "tsnd -r tsconfig-paths/register -r dotenv/config express-tus",
@@ -16,10 +17,10 @@
     "server": "tsnd -r dotenv/config server"
   },
   "dependencies": {
+    "@logtape/logtape": "^2.0.5",
     "dotenv": "17.3.1",
     "express": "^5.2.1",
-    "node-uploadx": "^6.2.1",
-    "winston": "3.19.0"
+    "node-uploadx": "^6.2.1"
   },
   "devDependencies": {
     "@types/express": "5.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,17 +42,17 @@
         "typescript-eslint": "^8.35.0"
       },
       "engines": {
-        "node": ">=14.18.20",
-        "npm": ">=7.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "examples": {
       "version": "6.2.1",
       "dependencies": {
+        "@logtape/logtape": "^2.0.5",
         "dotenv": "17.3.1",
         "express": "^5.2.1",
-        "node-uploadx": "^6.2.1",
-        "winston": "3.19.0"
+        "node-uploadx": "^6.2.1"
       },
       "devDependencies": {
         "@types/express": "5.0.6",
@@ -1583,15 +1583,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1614,17 +1605,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@dabh/diagnostics": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
-      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@so-ric/colorspace": "^1.1.6",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3087,6 +3067,15 @@
         "tslib": "2"
       }
     },
+    "node_modules/@logtape/logtape": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@logtape/logtape/-/logtape-2.0.5.tgz",
+      "integrity": "sha512-UizDkh20ZPJVOddRxG1F77WhHdlNl/sbQgoO8T534R7XvUBMAJ9En9f35u+meW2tRsNLvjz6R87Zanwf53tspQ==",
+      "funding": [
+        "https://github.com/sponsors/dahlia"
+      ],
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -4011,16 +4000,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@so-ric/colorspace": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
-      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
-      "license": "MIT",
-      "dependencies": {
-        "color": "^5.0.2",
-        "text-hex": "1.0.x"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -4358,12 +4337,6 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
-    },
-    "node_modules/@types/triple-beam": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
-      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -5083,6 +5056,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -5632,19 +5606,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/color": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
-      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^3.1.3",
-        "color-string": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5664,48 +5625,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
-      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/color-string/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
-      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
-    "node_modules/color/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -6019,12 +5938,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -6976,12 +6889,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-      "license": "MIT"
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -7068,12 +6975,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-      "license": "MIT"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -8736,12 +8637,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-      "license": "MIT"
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8992,23 +8887,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/logform": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
-      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "1.6.0",
-        "@types/triple-beam": "^1.3.2",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -9504,15 +9382,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "license": "MIT",
-      "dependencies": {
-        "fn.name": "1.x.x"
-      }
-    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -10006,20 +9875,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -10314,15 +10169,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-stable-stringify": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -10547,15 +10393,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -10577,15 +10414,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -10893,12 +10721,6 @@
         "node": "*"
       }
     },
-    "node_modules/text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "license": "MIT"
-    },
     "node_modules/thingies": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
@@ -10972,15 +10794,6 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
-      }
-    },
-    "node_modules/triple-beam": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -11440,12 +11253,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
-    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -11530,42 +11337,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/winston": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
-      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.8",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.7.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.9.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
-      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
-      "license": "MIT",
-      "dependencies": {
-        "logform": "^2.7.0",
-        "readable-stream": "^3.6.2",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/word-wrap": {
@@ -11854,6 +11625,7 @@
       "version": "6.2.1",
       "license": "MIT",
       "dependencies": {
+        "@logtape/logtape": "^2.0.5",
         "bytes": "^3.1.0",
         "multiparty": "^4.2.2"
       },
@@ -11862,7 +11634,7 @@
         "@types/multiparty": "4.2.1"
       },
       "engines": {
-        "node": ">=14.18.20"
+        "node": ">=20.0.0"
       }
     },
     "packages/gcs": {
@@ -11878,7 +11650,7 @@
         "@types/node-fetch": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.18.20"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@uploadx/core": "^6.2.1"
@@ -11893,7 +11665,7 @@
         "@uploadx/s3": "^6.2.1"
       },
       "engines": {
-        "node": ">=14.18.20"
+        "node": ">=20.0.0"
       }
     },
     "packages/s3": {
@@ -11911,7 +11683,7 @@
         "aws-sdk-client-mock": "^4.0.1"
       },
       "engines": {
-        "node": ">=14.18.20"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@uploadx/core": "^6.2.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "clean": "rimraf ./tsconfig.tsbuildinfo ./lib"
   },
   "dependencies": {
+    "@logtape/logtape": "^2.0.5",
     "bytes": "^3.1.0",
     "multiparty": "^4.2.2"
   },

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -26,6 +26,7 @@ import {
   isValidationError,
   Logger,
   pick,
+  uploadxLogger,
   setHeaders,
   tokenize,
   UploadxError
@@ -90,7 +91,7 @@ export abstract class BaseHandler<TFile extends UploadxFile>
     if (config.userIdentifier) {
       this.getUserId = config.userIdentifier;
     }
-    this.logger = this.storage.logger;
+    this.logger = uploadxLogger.getChild(this.constructor.name);
     this.assembleErrors();
     this.compose();
   }
@@ -116,7 +117,7 @@ export abstract class BaseHandler<TFile extends UploadxFile>
       handler && this.registeredHandlers.set(method.toUpperCase(), handler);
       // handler && this.cors.allowedMethods.push(method.toUpperCase());
     });
-    this.logger.debug('Registered handlers: %s', [...this.registeredHandlers.keys()].join(', '));
+    this.logger.debug(`Registered handlers: ${[...this.registeredHandlers.keys()].join(', ')}`);
   }
 
   assembleErrors(customErrors = {}): void {
@@ -135,8 +136,8 @@ export abstract class BaseHandler<TFile extends UploadxFile>
       res.writeHead(204, { 'Content-Length': 0 }).end();
       return;
     }
-    req.on('error', err => this.logger.error('[request error]: %O', err));
-    this.logger.debug('[request]: %s %s', req.method, req.url);
+    req.on('error', error => this.logger.error('Request error', { error }));
+    this.logger.debug('Request {method} {url}', { method: req.method, url: req.url });
     const handler = this.registeredHandlers.get(req.method as string);
     if (!handler) {
       return this.sendError(res, { uploadxErrorCode: ERRORS.METHOD_NOT_ALLOWED } as UploadxError);
@@ -149,13 +150,12 @@ export abstract class BaseHandler<TFile extends UploadxFile>
       .call(this, req, res)
       .then(async (file: TFile | UploadList): Promise<void> => {
         if ('status' in file && file.status) {
-          this.logger.debug(
-            '[%s]: %s: %d/%d',
-            file.status,
-            file.name,
-            file.bytesWritten,
-            file.size
-          );
+          this.logger.debug('Upload {status}: {name} {bytesWritten}/{size}', {
+            status: file.status,
+            name: file.name,
+            bytesWritten: file.bytesWritten,
+            size: file.size
+          });
           this.listenerCount(file.status) &&
             this.emit(file.status, { ...file, request: pick(req, ['headers', 'method', 'url']) });
           if (file.status === 'completed') {
@@ -178,15 +178,18 @@ export abstract class BaseHandler<TFile extends UploadxFile>
       })
       .catch((error: Error) => {
         const keys = Object.getOwnPropertyNames(error) as (keyof Error)[];
-        const err = pick(error, [
+        const sanitizedError = pick(error, [
           'name',
           ...(isUploadxError(error) ? keys.filter(k => k !== 'stack') : keys)
         ]) as UploadxError;
-        const errorEvent = { ...err, request: pick(req, ['headers', 'method', 'url']) };
-        this.listenerCount('error') && this.emit('error', errorEvent);
-        this.logger.error('[error]: %O', errorEvent);
+        const errorPayload = {
+          ...sanitizedError,
+          request: pick(req, ['headers', 'method', 'url'])
+        };
+        this.listenerCount('error') && this.emit('error', errorPayload);
+        this.logger.error('{errorPayload.message} {*}', { errorPayload });
         if ('aborted' in req && req['aborted']) return;
-        return this.sendError(res, err);
+        return this.sendError(res, sanitizedError);
       });
   };
 

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -1,4 +1,4 @@
-import { HttpError, logger } from '../utils';
+import { HttpError } from '../utils';
 import { File } from './file';
 import { BaseStorageOptions } from './storage';
 
@@ -19,8 +19,7 @@ export class ConfigHandler {
     },
     path: '/files',
     validation: {},
-    maxMetadataSize: '4MB',
-    logger: logger
+    maxMetadataSize: '4MB'
   };
 
   private _config = this.set(ConfigHandler.defaults);

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -67,8 +67,8 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     this.isReady = false;
     this.accessCheck()
       .then(() => (this.isReady = true))
-      .catch(err => {
-        this.logger.error('Storage access check failed: %O', err);
+      .catch((error: unknown) => {
+        this.logger.error('Storage access check failed {error.message}', { error });
       });
   }
 

--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -21,7 +21,7 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
     super(config);
     this.directory = (config?.directory || join(tmpdir(), 'uploadx_meta')).replace(/\\/g, '/');
     this.accessCheck().catch(err => {
-      this.logger.error('Metadata storage access check failed: %O', err);
+      this.logger.error('Metadata storage access check failed: {err}', { err });
     });
   }
 

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -1,5 +1,5 @@
 import { FileName } from './file';
-import { logger, Logger } from '../utils';
+import { Logger, uploadxLogger } from '../utils';
 
 /** @experimental */
 export interface UploadListEntry {
@@ -19,7 +19,6 @@ export interface UploadList {
 export interface MetaStorageOptions {
   prefix?: string;
   suffix?: string;
-  logger?: Logger;
 }
 
 /**
@@ -28,14 +27,13 @@ export interface MetaStorageOptions {
 export class MetaStorage<T> {
   prefix = '';
   suffix = '';
-  logger: Logger;
+  logger: Logger = uploadxLogger.getChild(this.constructor.name);
 
   constructor(config?: MetaStorageOptions) {
     this.prefix = config?.prefix || '';
     this.suffix = config?.suffix || METAFILE_EXTNAME;
     this.prefix && FileName.INVALID_PREFIXES.push(this.prefix);
     this.suffix && FileName.INVALID_SUFFIXES.push(this.suffix);
-    this.logger = config?.logger || logger;
   }
 
   /**

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -1,9 +1,9 @@
 import bytes from 'bytes';
 import { setInterval } from 'timers';
-import { inspect } from 'util';
 import { IncomingMessage, UploadxResponse } from '../types';
 import {
   Cache,
+  configureSimpleLogger,
   ErrorMap,
   ErrorResponses,
   ERRORS,
@@ -15,6 +15,7 @@ import {
   LogLevel,
   normalizeHookResponse,
   normalizeOnErrorResponse,
+  uploadxLogger,
   toMilliseconds,
   typeis,
   Validation,
@@ -99,8 +100,6 @@ export interface BaseStorageOptions<T extends File> {
    * ```
    */
   expiration?: ExpirationOptions;
-  /** Custom logger injection */
-  logger?: Logger;
   /**
    * Set built-in logger severity level
    * @defaultValue 'none'
@@ -121,12 +120,16 @@ export abstract class BaseStorage<TFile extends File> {
   checksumTypes: string[] = [];
   errorResponses = {} as ErrorResponses;
   cache: Cache<TFile>;
-  logger: Logger;
+  logger: Logger = uploadxLogger.getChild(this.constructor.name);
   protected namingFunction: (file: TFile, req: any) => string;
   protected validation = new Validator<TFile>();
   abstract meta: MetaStorage<TFile>;
 
   protected constructor(public config: BaseStorageOptions<TFile>) {
+    // Configure the logger if a logLevel is specified
+    if (config.logLevel) {
+      configureSimpleLogger(config.logLevel);
+    }
     const configHandler = new ConfigHandler();
     const opts = configHandler.set(config);
     this.path = opts.path;
@@ -139,13 +142,7 @@ export abstract class BaseStorage<TFile extends File> {
     this.maxUploadSize = bytes.parse(opts.maxUploadSize);
     this.maxMetadataSize = bytes.parse(opts.maxMetadataSize);
     this.cache = new Cache(1000, 300);
-    this.logger = opts.logger;
-    if (opts.logLevel && 'logLevel' in this.logger) {
-      this.logger.logLevel = opts.logLevel;
-    }
-    this.logger.debug(
-      `${this.constructor.name} config: ${inspect({ ...config, logger: this.logger.constructor })}`
-    );
+    this.logger.debug('configuration: {config}', { config });
     const purgeInterval = toMilliseconds(opts.expiration?.purgeInterval);
     if (purgeInterval) {
       this.startAutoPurge(purgeInterval);
@@ -289,7 +286,10 @@ export abstract class BaseStorage<TFile extends File> {
 
   protected startAutoPurge(purgeInterval: number): void {
     if (purgeInterval >= 2147483647) throw Error('“purgeInterval” must be less than 2147483647 ms');
-    setInterval(() => void this.purge().catch(e => this.logger.error(e)), purgeInterval);
+    setInterval(
+      () => void this.purge().catch(e => this.logger.error('purge error: {e}', { e })),
+      purgeInterval
+    );
   }
 
   protected updateTimestamps(file: TFile): TFile {

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,80 +1,62 @@
-import { formatWithOptions } from 'util';
+import {
+  configureSync,
+  getLogger,
+  getConsoleSink,
+  type LogLevel as LogTapeLogLevel,
+  type Logger as LogTapeLogger
+} from '@logtape/logtape';
 
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'none';
-const levels = ['debug', 'info', 'warn', 'error', 'none'];
+export type LogLevel = LogTapeLogLevel;
 
-enum PriorityOf {
-  debug,
-  info,
-  warn,
-  error,
-  none
-}
+export type Logger = LogTapeLogger;
 
-export interface LoggerOptions {
-  logger?: Logger;
-  logLevel?: LogLevel;
-  label?: string;
-  write?: (data: unknown[], level?: LogLevel) => void;
-}
+/**
+ * The primary logger for the uploadx library.
+ * Applications should configure the 'uploadx' category.
+ *
+ * @example
+ * ```ts
+ * await configure({
+ *   sinks: { console: getConsoleSink() },
+ *   loggers: [{ category: ['uploadx'], lowestLevel: 'info', sinks: ['console'] }]
+ * });
+ * ```
+ */
+export const uploadxLogger: LogTapeLogger = getLogger(['uploadx']);
 
-export interface Logger {
-  logLevel?: LogLevel;
-  debug(...data: any[]): void;
-  info(...data: any[]): void;
-  warn(...data: any[]): void;
-  error(...data: any[]): void;
+/**
+ * Normalizes legacy log levels (e.g. 'warn') to LogTape's format
+ */
+function toLogTapeLevel(level: string): LogTapeLogLevel {
+  return level === 'warn' ? 'warning' : (level as LogTapeLogLevel);
 }
 
 /**
- * Basic logger implementation
+ * Configures the LogTape logger for simple console output if a logLevel is provided and not 'none'.
+ * This function is called from the Storage constructor to enable logging based on user configuration.
  */
-export class BasicLogger implements Logger {
-  label: string;
-  private readonly logger: Logger;
-  private _logLevel: LogLevel = 'none';
-
-  constructor(readonly options: LoggerOptions = {}) {
-    this.logger = options.logger || console;
-    this.label = options.label ?? 'uploadx:';
-    if (options.logLevel) this.logLevel = options.logLevel;
-    if (options.write) this.write = options.write;
-  }
-
-  get logLevel(): LogLevel {
-    return this._logLevel;
-  }
-
-  set logLevel(value: LogLevel) {
-    if (value && !levels.includes(value)) {
-      throw new Error(`Invalid log level: ${value}, supported levels are: ${levels.join(', ')}.`);
-    }
-    this._logLevel = value;
-  }
-
-  write = (data: unknown[], level: Exclude<LogLevel, 'none'>): void => {
-    if (PriorityOf[level] >= PriorityOf[this._logLevel]) {
-      const message = formatWithOptions({ depth: 2, maxStringLength: 80 }, ...data);
-      const timestamp = new Date().toISOString();
-      this.logger[level](`${timestamp} ${level.toUpperCase()} ${this.label} ${message}`);
-    }
-  };
-
-  info(...data: unknown[]): void {
-    this.write(data, 'info');
-  }
-
-  warn(...data: unknown[]): void {
-    this.write(data, 'warn');
-  }
-
-  error(...data: unknown[]): void {
-    this.write(data, 'error');
-  }
-
-  debug(...data: unknown[]): void {
-    this.write(data, 'debug');
-  }
+export function configureSimpleLogger(logLevel: string | undefined): void {
+  if (!logLevel || logLevel === 'none') return;
+  configureSync({
+    sinks: { console: getConsoleSink() },
+    loggers: [
+      {
+        category: ['uploadx'],
+        lowestLevel: toLogTapeLevel(logLevel),
+        sinks: ['console']
+      },
+      // Suppress internal LogTape messages
+      {
+        category: ['logtape', 'meta'],
+        lowestLevel: 'warning',
+        sinks: ['console']
+      }
+    ]
+  });
 }
 
-export const logger = new BasicLogger();
+/** @deprecated Use `uploadxLogger` instead */
+export const logger = uploadxLogger;
+
+// Re-export for library consumers who may need to create their own loggers
+export { configureSync, getConsoleSink, getLogger };

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -125,7 +125,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
     this.isReady = false;
     this.accessCheck()
       .then(() => (this.isReady = true))
-      .catch(err => this.logger.error('Storage access check failed: %O', err));
+      .catch(error => this.logger.error('Storage access check failed: {error.message}', { error }));
   }
 
   normalizeError(error: ClientError): HttpError {
@@ -171,7 +171,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
     file.uri = res.headers.location as string;
     if (this.config.clientDirectUpload) {
       file.GCSUploadURI = file.uri;
-      this.logger.debug('send uploadURI to client: %s', file.GCSUploadURI);
+      this.logger.debug('Send uploadURI to client', { uri: file.GCSUploadURI });
       file.status = 'created';
       return file;
     }
@@ -225,7 +225,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
         return range ? getRangeEnd(range) : 0;
       } else if (res.ok) {
         const data = (await res.json()) as Record<string, any>;
-        this.logger.debug('uploaded %O', data);
+        this.logger.debug('Upload completed', { data });
         return size;
       }
       const message = await res.text();
@@ -235,8 +235,8 @@ export class GCStorage extends BaseStorage<GCSFile> {
         config: { uri },
         name: 'FetchError'
       });
-    } catch (err) {
-      this.logger.error(uri, err);
+    } catch (error) {
+      this.logger.error('Upload chunk failed', { uri, error });
       return NaN;
     }
   }

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -26,7 +26,9 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
     const keyFile = config.keyFile || process.env.S3_KEYFILE;
     keyFile && (config.credentials = fromIni({ configFilepath: keyFile }));
     const clientConfig = { ...config };
-    clientConfig.logger = toBoolean(process.env.S3_DEBUG) ? this.logger : undefined;
+    clientConfig.logger = toBoolean(process.env.S3_DEBUG)
+      ? (this.logger as unknown as S3ClientConfig['logger'])
+      : undefined;
     this.client = new S3Client(clientConfig);
   }
 

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -150,7 +150,7 @@ export class S3Storage extends BaseStorage<S3File> {
     this.isReady = false;
     this.accessCheck()
       .then(() => (this.isReady = true))
-      .catch(err => this.logger.error('Storage access check failed: %O', err));
+      .catch(error => this.logger.error('Storage access check failed: {error.message}', { error }));
   }
 
   normalizeError(error: AWSError): HttpError {
@@ -327,8 +327,8 @@ export class S3Storage extends BaseStorage<S3File> {
     try {
       const params = { Bucket: this.bucket, Key: file.name, UploadId: file.UploadId };
       await this.client.send(new AbortMultipartUploadCommand(params));
-    } catch (err) {
-      this.logger.error('_abortMultipartUploadError: ', err);
+    } catch (error) {
+      this.logger.error('Abort multipart upload failed', { error });
     }
   }
 }

--- a/test/base-handler.spec.ts
+++ b/test/base-handler.spec.ts
@@ -44,7 +44,8 @@ describe('BaseHandler', () => {
   it('should check user (custom)', async () => {
     uploader = new TestUploader({
       storage: testStorage,
-      userIdentifier: (_, res) => res.locals.user_id // eslint-disable-line
+      userIdentifier: (_req, res) =>
+        String((res as { locals?: { user_id?: string } }).locals?.user_id ?? '')
     });
     const res = createResponse({ locals: { user_id: '12345' } });
     const req = createRequest({ url: '/files' });
@@ -87,5 +88,42 @@ describe('BaseHandler', () => {
     ['/3/files/4', '']
   ])('nodejs: getId(%p) === %p', (url, id) => {
     expect(uploader.getId({ url } as http.IncomingMessage)).toBe(id);
+  });
+
+  interface MockReq extends http.IncomingMessage {
+    user?: { _id: string };
+  }
+
+  it('should emit error event with request context', async () => {
+    const res = createResponse();
+    const req = createRequest({ method: 'GET', url: '/files' }) as unknown as MockReq;
+
+    const testUploader = new TestUploader({
+      storage: testStorage,
+      userIdentifier: r => (r as MockReq).user?._id || ''
+    });
+    testStorage.isReady = true;
+
+    req.user = { _id: 'user123' };
+
+    const errorSpy = jest.fn<void, [unknown]>();
+    testUploader.on('error', errorSpy);
+    jest.spyOn(testUploader.storage, 'list').mockRejectedValue(new Error('Test Error'));
+
+    testUploader.handle(req as http.IncomingMessage, res);
+    await new Promise(setImmediate);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+
+    const event = errorSpy.mock.calls[0][0];
+    expect(event).toMatchObject({
+      message: 'Test Error',
+      request: {
+        method: 'GET',
+        url: '/files'
+      }
+    });
+    expect(event).toHaveProperty('request.headers');
+    expect(event).toHaveProperty('stack');
   });
 });

--- a/test/disk-storage.spec.ts
+++ b/test/disk-storage.spec.ts
@@ -37,19 +37,6 @@ describe('DiskStorage', () => {
       storage = new DiskStorage(options);
       expect(storage.directory).toBe(directory);
     });
-
-    it('should share logger', () => {
-      storage = new DiskStorage();
-      expect(storage.logger).toBe(storage.meta.logger);
-    });
-
-    it('should share custom logger', () => {
-      const logger = console;
-      const consoleDebugMock = jest.spyOn(console, 'debug').mockImplementation();
-      storage = new DiskStorage({ logger });
-      expect(storage.logger).toBe(storage.meta.logger);
-      consoleDebugMock.mockRestore();
-    });
   });
 
   describe('.create()', () => {

--- a/test/gcs-storage.spec.ts
+++ b/test/gcs-storage.spec.ts
@@ -45,10 +45,6 @@ describe('GCStorage', () => {
       expect(storage.meta).toBeInstanceOf(GCSMetaStorage);
       expect(storage.bucket).toBeDefined();
     });
-
-    it('should share logger', () => {
-      expect(storage.logger).toBe(storage.meta.logger);
-    });
   });
 
   describe('.create()', () => {

--- a/test/s3-storage.spec.ts
+++ b/test/s3-storage.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { mockClient } from 'aws-sdk-client-mock';
-import { AWSError, S3MetaStorage, S3Storage, S3StorageOptions } from '../packages/s3/src';
+import { AWSError, S3Storage, S3StorageOptions } from '../packages/s3/src';
 import { authRequest, metafile, storageOptions, testfile } from './shared';
 
 jest.mock('@aws-sdk/s3-request-presigner');
@@ -48,22 +48,6 @@ describe('S3Storage', () => {
     it('default options if no options are provided', () => {
       storage = new S3Storage();
       expect(storage).toBeInstanceOf(S3Storage);
-    });
-
-    it('logger', () => {
-      process.env.S3_DEBUG = 'true';
-      const logger = console;
-      const consoleDebugMock = jest.spyOn(console, 'debug').mockImplementation();
-      storage = new S3Storage({ logger });
-      expect(storage.client.config.logger).toBe(logger);
-      expect((storage.meta as S3MetaStorage).client.config.logger).toBe(logger);
-      process.env.S3_DEBUG = undefined;
-      storage = new S3Storage({ logger });
-      expect(storage.client.config.logger).toBeUndefined();
-      expect((storage.meta as S3MetaStorage).client.config.logger).toBeUndefined();
-      expect(storage.logger).toBe(logger);
-      expect(storage.meta.logger).toBe(logger);
-      consoleDebugMock.mockRestore();
     });
   });
 

--- a/test/shared/uploader.ts
+++ b/test/shared/uploader.ts
@@ -18,7 +18,7 @@ export class TestStorage extends BaseStorage<File> {
 
   constructor(config = {} as BaseStorageOptions<File>) {
     super(config);
-    this.meta = new MetaStorage<File>(config);
+    this.meta = new MetaStorage<File>();
   }
 
   create(req: any, file: FileInit): Promise<File> {

--- a/test/storage.spec.ts
+++ b/test/storage.spec.ts
@@ -4,152 +4,94 @@ import { metafile, TestStorage } from './shared';
 describe('BaseStorage', () => {
   let storage: TestStorage;
 
-  async function createFile(overrides: Partial<File> = {}): Promise<File> {
-    const init = {
-      ...metafile,
-      metadata: { ...metafile.metadata },
-      ...overrides
+  beforeEach(() => (storage = new TestStorage()));
+
+  async function createAndSaveMetafile(): Promise<File> {
+    const init: File = {
+      id: 'size.409',
+      originalName: 'testfile.mp4',
+      size: 409,
+      contentType: 'video/mp4'
     } as File;
     const created = await storage.create({}, init);
     return storage.saveMeta(created);
   }
 
-  it('should share logger', () => {
-    storage = new TestStorage();
-    expect(storage.logger).toBe(storage.meta.logger);
-  });
-
-  it('should share custom logger', () => {
-    const logger = console;
-    const consoleDebugMock = jest.spyOn(console, 'debug').mockImplementation();
-    storage = new TestStorage({ logger });
-    expect(storage.logger).toBe(storage.meta.logger);
-    consoleDebugMock.mockRestore();
-  });
-
   it('should set maxUploadSize', () => {
-    storage = new TestStorage();
     expect(storage.maxUploadSize).toBe(5497558138880);
   });
 
-  it('should validate', () => {
-    storage = new TestStorage();
-    return expect(storage.validate(metafile)).resolves.toBeUndefined();
+  it('should validate', async () => {
+    await expect(storage.validate(metafile)).resolves.toBeUndefined();
   });
 
-  it('should validate error', () => {
-    storage = new TestStorage();
-    return expect(storage.validate({ ...metafile, name: '../file.ext' })).rejects.toHaveProperty(
+  it('should validate error', async () => {
+    await expect(storage.validate({ ...metafile, name: '../file.ext' })).rejects.toHaveProperty(
       'statusCode'
     );
   });
 
   it('should check if expired', async () => {
-    storage = new TestStorage();
     await expect(
       storage.checkIfExpired({ ...metafile, expiredAt: Date.now() - 100 })
     ).rejects.toHaveProperty('uploadxErrorCode', 'Gone');
   });
 
-  it('should support logger', () => {
-    jest.useFakeTimers().setSystemTime(new Date('2022-02-02'));
-    const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
-    storage = new TestStorage({ logLevel: 'warn' });
-    storage.logger.warn('some', 'warning');
-    expect(consoleWarnMock).toHaveBeenCalledWith(
-      '2022-02-02T00:00:00.000Z WARN uploadx: some warning'
-    );
-    consoleWarnMock.mockRestore();
-    jest.useRealTimers();
-  });
-
-  it('should support custom logger', () => {
-    const consoleDebugMock = jest.spyOn(console, 'debug').mockImplementation();
-    storage = new TestStorage({ logger: console });
-    storage.logger.debug('some', 'value');
-    expect(consoleDebugMock).toHaveBeenCalledWith('some', 'value');
-    consoleDebugMock.mockRestore();
+  it('should check if not expired', async () => {
+    storage = new TestStorage({ expiration: { maxAge: '1h' } });
+    expect(storage.checkIfExpired({ ...metafile, expiredAt: Date.now() + 1000 })).toBeTruthy();
   });
 
   it('should save meta and update cache', async () => {
-    storage = new TestStorage();
-    const created = await createFile({ bytesWritten: 100 });
-    const result = await storage.saveMeta({
-      ...created,
-      bytesWritten: 200,
-      status: 'part' as const
-    });
-
-    expect(result.bytesWritten).toBe(200);
-    expect(storage.cache.get(metafile.id)!.bytesWritten).toBe(200);
+    const meta = await createAndSaveMetafile();
+    expect(storage.cache.get(meta.id)).toMatchObject(meta);
   });
 
-  it('should update user metadata', async () => {
-    storage = new TestStorage();
-    await createFile();
-
-    const result = await storage.update(
-      { id: metafile.id },
-      {
-        metadata: { name: 'newname.mp4', customKey: 'customValue', tags: ['tag1', 'tag2', 'tag3'] }
-      }
-    );
-
-    expect(result.metadata.name).toBe('newname.mp4');
-    expect(result.metadata.customKey).toBe('customValue');
-    expect(result.metadata.tags).toEqual(['tag1', 'tag2', 'tag3']);
-    expect(storage.cache.get(metafile.id)!.metadata.name).toBe('newname.mp4');
+  it('should get meta from cache', async () => {
+    const meta = await createAndSaveMetafile();
+    const result = await storage.getMeta(meta.id);
+    expect(result.id).toBe(meta.id);
+    expect(result.name).toBe(meta.name);
   });
 
-  it('should call meta.save (not touch) when user metadata changes', async () => {
-    storage = new TestStorage();
-    await createFile();
-
-    const saveSpy = jest.spyOn(storage.meta, 'save');
-    const touchSpy = jest.spyOn(storage.meta, 'touch');
-
-    await storage.update(
-      { id: metafile.id },
-      {
-        metadata: { name: 'newname.mp4', customKey: 'customValue', tags: ['tag1', 'tag2', 'tag3'] }
-      }
-    );
-
-    expect(saveSpy).toHaveBeenCalledTimes(1);
-    expect(touchSpy).not.toHaveBeenCalled();
+  it('should delete meta and cache', async () => {
+    const meta = await createAndSaveMetafile();
+    expect(storage.cache.get(meta.id)).toBeDefined();
+    await storage.deleteMeta(meta.id);
+    expect(storage.cache.get(meta.id)).toBeUndefined();
   });
 
-  it('should call meta.save when user metadata deep changed', async () => {
-    storage = new TestStorage();
-    await createFile({
-      metadata: { customKey: 'customValue', tags: ['tag1', 'tag2', 'tag3'] }
-    });
-
-    const saveSpy = jest.spyOn(storage.meta, 'save');
-    const touchSpy = jest.spyOn(storage.meta, 'touch');
-
-    await storage.update(
-      { id: metafile.id },
-      {
-        metadata: { customKey: 'customValue', tags: ['tag1', 'tag2', 'tag4'] }
-      }
-    );
-
-    expect(saveSpy).toHaveBeenCalledTimes(1);
-    expect(touchSpy).toHaveBeenCalledTimes(0);
+  it('should touch and update cache', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2022-02-02'));
+    const meta = await createAndSaveMetafile();
+    const updated = await storage.update(meta, { name: 'newname.mp4' });
+    expect(updated.name).toBe('newname.mp4');
+    expect(storage.cache.get(meta.id)?.name).toBe('newname.mp4');
+    jest.useRealTimers();
   });
 
-  it('should call meta.touch when only bytesWritten or expiredAt change', async () => {
-    storage = new TestStorage();
-    await createFile({ bytesWritten: 100 });
+  it('should list uploads', async () => {
+    const list = await storage.list();
+    expect(list).toHaveProperty('items');
+  });
 
-    const saveSpy = jest.spyOn(storage.meta, 'save');
-    const touchSpy = jest.spyOn(storage.meta, 'touch');
+  it('should set maxMetadataSize', () => {
+    storage = new TestStorage({ maxMetadataSize: '4MB' });
+    expect(storage.maxMetadataSize).toBe(4194304);
+  });
 
-    const cached = storage.cache.get(metafile.id)!;
-    await storage.saveMeta({ ...cached, bytesWritten: 200, expiredAt: '2099-01-01T00:00:00.000Z' });
+  it('should have loggers', () => {
+    expect(storage.logger).toBeDefined();
+    expect(storage.meta.logger).toBeDefined();
+    expect(storage.logger).not.toBe(storage.meta.logger);
+  });
 
-    expect(touchSpy).toHaveBeenCalledTimes(1);
-    expect(saveSpy).not.toHaveBeenCalled();
+  it('should configure logger via logLevel option', () => {
+    const spy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    storage = new TestStorage({ logLevel: 'debug' });
+    // Verify that debug logging is active
+    expect(spy).toHaveBeenCalled(); // this.logger.debug('configuration: {config}', { config });
+    expect(storage.config.logLevel).toBe('debug');
+    spy.mockRestore();
   });
 });

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -263,38 +263,4 @@ describe('utils', () => {
       });
     });
   });
-
-  describe('BasicLogger', () => {
-    it('should default silent', () => {
-      const logger = utils.logger;
-      const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
-      logger.error('test');
-      expect(consoleErrorMock).not.toHaveBeenCalled();
-      consoleErrorMock.mockRestore();
-    });
-
-    it('should support logLevels', () => {
-      const logger = utils.logger;
-      const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
-      const consoleDebugMock = jest.spyOn(console, 'debug').mockImplementation();
-      logger.logLevel = 'info';
-      logger.error('test');
-      logger.debug('test');
-      expect(consoleErrorMock).toHaveBeenCalledTimes(1);
-      expect(consoleDebugMock).not.toHaveBeenCalled();
-      consoleErrorMock.mockRestore();
-      consoleDebugMock.mockRestore();
-    });
-
-    it('should format log', () => {
-      jest.useFakeTimers().setSystemTime(new Date('2022-02-02'));
-      const logger = utils.logger;
-      logger.logLevel = 'info';
-      const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
-      logger.error('test');
-      expect(consoleErrorMock).toHaveBeenCalledWith('2022-02-02T00:00:00.000Z ERROR uploadx: test');
-      consoleErrorMock.mockRestore();
-      jest.useRealTimers();
-    });
-  });
 });


### PR DESCRIPTION
Replaces BasicLogger with [@logtape/logtape](https://logtape.org/) for structured logging.

### BREAKING CHANGE

Removed `logger` option from `BaseStorageOptions`. Use one of:

- `logLevel` option for quick setup
- LogTape [`configure()`](https://logtape.org/manual/adaptors) for full control
- [`@logtape/adaptor-*`](https://logtape.org/manual/adaptors) to bridge winston/pino/log4js