### PR TITLE
feat(gcs): add emulator support and env overrides for API endpoints

### DIFF
--- a/packages/gcs/src/gcs-config.ts
+++ b/packages/gcs/src/gcs-config.ts
@@ -1,6 +1,44 @@
 export class GCSConfig {
   static bucketName = 'node-uploadx';
-  static uploadAPI = 'https://storage.googleapis.com/upload/storage/v1/b';
-  static storageAPI = 'https://storage.googleapis.com/storage/v1/b';
+
+  // Default endpoints
+  static defaultUploadAPI = 'https://storage.googleapis.com/upload/storage/v1/b';
+  static defaultStorageAPI = 'https://storage.googleapis.com/storage/v1/b';
+
+  // ENV overrides
+  static envUploadAPI = process.env.GCS_UPLOAD_API;
+  static envStorageAPI = process.env.GCS_STORAGE_API;
+
   static authScopes = ['https://www.googleapis.com/auth/devstorage.full_control'];
+
+  private static _uploadAPI?: string;
+  private static _storageAPI?: string;
+
+  static get emulatorHost(): string | undefined {
+    return process.env.STORAGE_EMULATOR_HOST;
+  }
+
+  static get isEmulator(): boolean {
+    return !!this.emulatorHost;
+  }
+
+  static get uploadAPI(): string {
+    if (!this._uploadAPI) {
+      this._uploadAPI =
+        this.envUploadAPI ||
+        (this.isEmulator
+          ? `http://${this.emulatorHost}/upload/storage/v1/b`
+          : this.defaultUploadAPI);
+    }
+    return this._uploadAPI;
+  }
+
+  static get storageAPI(): string {
+    if (!this._storageAPI) {
+      this._storageAPI =
+        this.envStorageAPI ||
+        (this.isEmulator ? `http://${this.emulatorHost}/storage/v1/b` : this.defaultStorageAPI);
+    }
+    return this._storageAPI;
+  }
 }

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -14,6 +14,7 @@ import {
   IncomingMessage,
   LocalMetaStorage,
   LocalMetaStorageOptions,
+  mapValues,
   MetaStorage,
   partMatch
 } from '@uploadx/core';
@@ -161,7 +162,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
     headers['X-Upload-Content-Type'] = file.contentType;
     origin && (headers['Origin'] = origin);
     const opts = {
-      body: JSON.stringify({ metadata: file.metadata }),
+      body: JSON.stringify({ metadata: mapValues(file.metadata, String) }),
       headers,
       method: 'POST' as const,
       params: { name: file.name, size: file.size, uploadType: 'resumable' },

--- a/test/__snapshots__/gcs-storage.spec.ts.snap
+++ b/test/__snapshots__/gcs-storage.spec.ts.snap
@@ -64,7 +64,7 @@ exports[`GCStorage .create() should request api and set status and uri 2`] = `
     ],
     [
       {
-        "body": "{"metadata":{"name":"testfile.mp4","size":64,"mimeType":"video/mp4","lastModified":1635398061454,"custom":"","sha1":"ZAPAntzKARqtb+j3B529GAOf3kI="}}",
+        "body": "{"metadata":{"name":"testfile.mp4","size":"64","mimeType":"video/mp4","lastModified":"1635398061454","custom":"","sha1":"ZAPAntzKARqtb+j3B529GAOf3kI="}}",
         "headers": {
           "Content-Type": "application/json; charset=utf-8",
           "Origin": "http://api.com",


### PR DESCRIPTION
- Detect GCS emulator via STORAGE_EMULATOR_HOST
- Allow custom upload/storage endpoints via GCS_UPLOAD_API and GCS_STORAGE_API env vars