### PR TITLE
refactor: add toString() to meta storages for cleaner debug output

### DIFF
--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -1,8 +1,8 @@
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { accessCheck, fsp, getFiles, removeFile } from '../utils';
 import { File } from './file';
 import { MetaStorage, MetaStorageOptions, UploadList } from './meta-storage';
-import { tmpdir } from 'os';
 
 export interface LocalMetaStorageOptions extends MetaStorageOptions {
   /**
@@ -70,6 +70,10 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
       }
     }
     return { items: uploads };
+  }
+
+  toString(): string {
+    return `[${this.constructor.name}: directory="${this.directory}", prefix="${this.prefix}", suffix="${this.suffix}"]`;
   }
 
   private accessCheck(): Promise<void> {

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -1,5 +1,6 @@
-import { FileName } from './file';
+import { inspect } from 'util';
 import { Logger, uploadxLogger } from '../utils';
+import { FileName } from './file';
 
 /** @experimental */
 export interface UploadListEntry {
@@ -78,6 +79,14 @@ export class MetaStorage<T> {
 
   getIdFromMetaName(name: string): string {
     return name.slice(this.prefix.length, -this.suffix.length);
+  }
+
+  toString(): string {
+    return `[${this.constructor.name}: prefix="${this.prefix}", suffix="${this.suffix}"]`;
+  }
+
+  [inspect.custom](): string {
+    return this.toString();
   }
 }
 

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -10,13 +10,14 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
   authClient: GoogleAuth;
   storageBaseURI: string;
   uploadBaseURI: string;
+  bucket: string;
 
   constructor(readonly config: GCSMetaStorageOptions = {}) {
     super(config);
     config.keyFile ||= process.env.GCS_KEYFILE;
-    const bucketName = config.bucket || process.env.GCS_BUCKET || GCSConfig.bucketName;
-    this.storageBaseURI = [GCSConfig.storageAPI, bucketName, 'o'].join('/');
-    this.uploadBaseURI = [GCSConfig.uploadAPI, bucketName, 'o'].join('/');
+    this.bucket = config.bucket || process.env.GCS_BUCKET || GCSConfig.bucketName;
+    this.storageBaseURI = [GCSConfig.storageAPI, this.bucket, 'o'].join('/');
+    this.uploadBaseURI = [GCSConfig.uploadAPI, this.bucket, 'o'].join('/');
     config.scopes ||= GCSConfig.authScopes;
     this.authClient = new GoogleAuth(config);
   }
@@ -68,5 +69,9 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
           createdAt: new Date(timeCreated)
         }))
     };
+  }
+
+  toString(): string {
+    return `[${this.constructor.name}: bucket="${this.bucket}", prefix="${this.prefix}", suffix="${this.suffix}"]`;
   }
 }

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -78,4 +78,8 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
     }
     return { items, prefix };
   }
+
+  toString(): string {
+    return `[${this.constructor.name}: bucket="${this.bucket}", prefix="${this.prefix}", suffix="${this.suffix}"]`;
+  }
 }


### PR DESCRIPTION
- Added `toString()` to `MetaStorage` to prevent huge logger instances from appearing in debug logs.