### PR TITLE
fix(s3): prevent crash on client upload abort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -275,20 +275,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.374.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.374.0.tgz",
-      "integrity": "sha512-pO1pqFBdIF28ZvnJmg58Erj35RLzXsTrjvHghdc/xgtSvodFFCNrUsPg6AP3On8eiw9elpHoS4P8jMx1pHDXEw==",
-      "deprecated": "This package has moved to @smithy/abort-controller",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^1.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-cognito-identity": {
       "version": "3.1003.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1003.0.tgz",
@@ -4429,31 +4415,6 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^1.2.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
-      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
@@ -8018,9 +7979,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -8029,7 +7990,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -14451,6 +14413,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -14626,7 +14603,6 @@
       "version": "6.2.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/abort-controller": "^3.374.0",
         "@aws-sdk/client-s3": "^3.485.0",
         "@aws-sdk/credential-providers": "^3.485.0",
         "@aws-sdk/s3-request-presigner": "^3.485.0"

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -32,7 +32,6 @@
     "clean": "rimraf ./tsconfig.tsbuildinfo && rimraf ./lib"
   },
   "dependencies": {
-    "@aws-sdk/abort-controller": "^3.374.0",
     "@aws-sdk/client-s3": "^3.485.0",
     "@aws-sdk/credential-providers": "^3.485.0",
     "@aws-sdk/s3-request-presigner": "^3.485.0"

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -1,4 +1,3 @@
-import bytes from 'bytes';
 import {
   AbortMultipartUploadCommand,
   CompleteMultipartUploadCommand,
@@ -14,6 +13,7 @@ import {
   waitUntilBucketExists
 } from '@aws-sdk/client-s3';
 import { fromIni } from '@aws-sdk/credential-providers';
+
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
   BaseStorage,
@@ -37,12 +37,15 @@ import {
   toSeconds,
   updateSize
 } from '@uploadx/core';
+import bytes from 'bytes';
+import { PassThrough } from 'stream';
 import { AWSError } from './aws-error';
 import { S3MetaStorage, S3MetaStorageOptions } from './s3-meta-storage';
 
 const BUCKET_NAME = 'node-uploadx';
 const MIN_PART_SIZE = 5 * 1024 * 1024;
 const PART_SIZE = 16 * 1024 * 1024;
+const PART_TIMEOUT = 300_000;
 
 export class S3File extends File {
   Parts?: Part[];
@@ -211,24 +214,44 @@ export class S3Storage extends BaseStorage<S3File> {
         return fail(ERRORS.UNSUPPORTED_CHECKSUM_ALGORITHM);
       }
       const partNumber = file.Parts.length + 1;
+      const upstream = part.body;
+      const body = upstream.pipe(new PassThrough());
+      const controller = new AbortController();
+      const abortSignal = controller.signal;
+      const onUpstreamGone = (): void => {
+        controller.abort();
+        body.destroy();
+      };
+      upstream.once('error', onUpstreamGone);
+      upstream.once('abort', onUpstreamGone);
+      const timeoutId = setTimeout(() => {
+        this.logger.warn(`Upload part timeout: ${file.name}, part ${partNumber}`);
+        onUpstreamGone();
+      }, PART_TIMEOUT);
+
       const params: UploadPartCommandInput = {
         Bucket: this.bucket,
         Key: file.name,
         UploadId: file.UploadId,
         PartNumber: partNumber,
-        Body: part.body,
+        Body: body,
         ContentLength: part.contentLength || 0
       };
       if (part.checksumAlgorithm === 'md5') {
         params.ContentMD5 = part.checksum;
       }
-      const controller = new AbortController();
-      const abortSignal = controller.signal;
-      part.body.on('error', _err => controller.abort());
-      const { ETag } = await this.client.send(new UploadPartCommand(params), { abortSignal });
-      const uploadPart: Part = { PartNumber: partNumber, Size: part.contentLength, ETag };
-      file.Parts = [...file.Parts, uploadPart];
-      file.bytesWritten += part.contentLength || 0;
+
+      try {
+        const { ETag } = await this.client.send(new UploadPartCommand(params), { abortSignal });
+        const uploadPart: Part = { PartNumber: partNumber, Size: part.contentLength, ETag };
+        file.Parts = [...file.Parts, uploadPart];
+        file.bytesWritten += part.contentLength || 0;
+      } finally {
+        clearTimeout(timeoutId);
+        upstream.removeListener('error', onUpstreamGone);
+        upstream.removeListener('abort', onUpstreamGone);
+        body.destroy();
+      }
     }
     this.cache.set(file.id, file);
     file.status = getFileStatus(file);

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -13,7 +13,6 @@ import {
   UploadPartCommandInput,
   waitUntilBucketExists
 } from '@aws-sdk/client-s3';
-import { AbortController } from '@aws-sdk/abort-controller';
 import { fromIni } from '@aws-sdk/credential-providers';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
@@ -223,8 +222,9 @@ export class S3Storage extends BaseStorage<S3File> {
       if (part.checksumAlgorithm === 'md5') {
         params.ContentMD5 = part.checksum;
       }
-      const abortSignal = new AbortController().signal;
-      part.body.on('error', _err => abortSignal.abort());
+      const controller = new AbortController();
+      const abortSignal = controller.signal;
+      part.body.on('error', _err => controller.abort());
       const { ETag } = await this.client.send(new UploadPartCommand(params), { abortSignal });
       const uploadPart: Part = { PartNumber: partNumber, Size: part.contentLength, ETag };
       file.Parts = [...file.Parts, uploadPart];


### PR DESCRIPTION
- Migrate S3 storage from @aws-sdk/abort-controller to native AbortController
- Add proper handling of client abort events during multipart upload to prevent crashes