### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,15 @@ jobs:
       matrix:
         node:
           - 20.x
-          - 22.x
           - 24.x
+          - 26.x
         os:
           - ubuntu-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       - name: Install dependencies


### PR DESCRIPTION
- Fix deprecation warning about Node.js 20 actions