### PR TITLE
feat: support custom baseUrl via config and environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ app.use('/files', uploadx({ directory: './uploads', maxUploadSize: '10GB' }));
 
 - `useRelativeLocation` Use relative urls. Default value: `false`
 
+- `baseUrl` Base URL for upload endpoints. If not provided, it is determined from the request.
+
 - `filename` File naming function
 
 - `userIdentifier` Get user identity
@@ -130,7 +132,9 @@ See [express-logtape.ts](examples/express-logtape.ts) for a complete example.
 
 ## Environment Variables
 
-`UPLOADX_SECRET` - Secret for salting file/user IDs (set to random string in production).
+- `UPLOADX_BASE_URL` - Overrides the base URL for upload links.
+
+- `UPLOADX_SECRET` - Secret for salting file/user IDs (set to random string in production).
 
 ## Project Structure
 

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -262,7 +262,10 @@ export abstract class BaseHandler<TFile extends UploadxFile>
   buildFileUrl(req: IncomingMessage, file: TFile): string {
     const { query, pathname = '' } = url.parse(req.originalUrl || (req.url as string), true);
     const relative = url.format({ pathname: `${pathname as string}/${file.id}`, query });
-    return this.storage.config.useRelativeLocation ? relative : getBaseUrl(req) + relative;
+    if (this.storage.config.useRelativeLocation) return relative;
+    const { baseUrl } = this.storage.config;
+    const base = typeof baseUrl === 'function' ? baseUrl(req) : baseUrl || getBaseUrl(req);
+    return base + relative;
   }
 
   protected finish(req: IncomingMessage, res: ServerResponse, response: UploadxResponse): void {

--- a/packages/core/src/handlers/uploadx.ts
+++ b/packages/core/src/handlers/uploadx.ts
@@ -108,7 +108,10 @@ export class Uploadx<TFile extends UploadxFile> extends BaseHandler<TFile> {
     const { query, pathname } = url.parse(req.originalUrl || (req.url as string), true);
     query.upload_id = file.id;
     const relative = url.format({ pathname, query });
-    return this.storage.config.useRelativeLocation ? relative : getBaseUrl(req) + relative;
+    if (this.storage.config.useRelativeLocation) return relative;
+    const { baseUrl } = this.storage.config;
+    const base = typeof baseUrl === 'function' ? baseUrl(req) : baseUrl || getBaseUrl(req);
+    return base + relative;
   }
 
   async getMetadata(req: IncomingMessage): Promise<Record<any, any>> {

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -1,4 +1,4 @@
-import { HttpError } from '../utils';
+import { getEnv, HttpError } from '../utils';
 import { File } from './file';
 import { BaseStorageOptions } from './storage';
 
@@ -8,6 +8,7 @@ export class ConfigHandler {
     maxUploadSize: '5TB',
     filename: ({ id }: File): string => id,
     useRelativeLocation: false,
+    baseUrl: getEnv('BASE_URL'),
     onComplete: (file: File) => file,
     onUpdate: (file: File) => file,
     onCreate: () => '',

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -63,10 +63,12 @@ export interface BaseStorageOptions<T extends File> {
   maxUploadSize?: number | string;
   /** File naming function */
   filename?: (file: T, req: any) => string;
-  /** Get user identity */
   userIdentifier?: UserIdentifier;
   /** Force relative URI in Location header */
   useRelativeLocation?: boolean;
+
+  /** Base URL for upload endpoints. If not provided, it is determined from the request. */
+  baseUrl?: string | ((req: any) => string);
   /** Callback function that is called when a new upload is created */
   onCreate?: OnCreate<T>;
   /** Callback function that is called when an upload is updated */

--- a/packages/core/src/utils/core-env.ts
+++ b/packages/core/src/utils/core-env.ts
@@ -1,0 +1,10 @@
+const CORE_ENV = {
+  UPLOADX_SECRET: 'UPLOADX_SECRET',
+  BASE_URL: 'UPLOADX_BASE_URL'
+} as const;
+
+/**
+ * Get environment variable by typed key
+ */
+export const getEnv = (key: keyof typeof CORE_ENV): string | undefined =>
+  process.env[CORE_ENV[key]];

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -117,18 +117,15 @@ export function getBaseUrl(req: http.IncomingMessage): string {
 /**
  * Extracts host with port from a http or https request.
  */
-export function extractHost(
-  req: http.IncomingMessage & { host?: string; hostname?: string }
-): string {
-  return getHeader(req, 'host');
-  // return req.host || req.hostname || getHeader(req, 'host'); // for express v5 / fastify
+function extractHost(req: http.IncomingMessage & { host?: string }): string {
+  return req.host || getHeader(req, 'host');
 }
 
 /**
  * Extracts protocol from a http or https request.
  */
-export function extractProto(req: http.IncomingMessage): string {
-  return getHeader(req, 'x-forwarded-proto').toLowerCase();
+function extractProto(req: http.IncomingMessage & { protocol?: string }): string {
+  return req.protocol || getHeader(req, 'x-forwarded-proto').toLowerCase();
 }
 
 export function responseToTuple<T extends ResponseBody>(

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './cache';
+export * from './core-env';
 export * from './errors';
 export * from './fs';
 export * from './http';

--- a/packages/core/src/utils/primitives.ts
+++ b/packages/core/src/utils/primitives.ts
@@ -1,8 +1,9 @@
 import { createHash, randomBytes } from 'crypto';
 import { isDeepStrictEqual } from 'util';
 import { Cache } from './cache';
+import { getEnv } from './core-env';
 
-const UPLOADX_SECRET = process.env.UPLOADX_SECRET || 'UPLOADX_SECRET';
+const UPLOADX_SECRET = getEnv('UPLOADX_SECRET') || 'UPLOADX_SECRET';
 
 export const pick = <T, K extends keyof T>(obj: T, whitelist: K[]): Pick<T, K> => {
   const result = {} as Pick<T, K>;


### PR DESCRIPTION
- Add `baseUrl?: string | ((req) => string)` to options.
- Prefer `req.host`/`req.protocol` over headers.