### PR TITLE
refactor(core): rename storage options fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ const app = express();
 app.use(
   '/uploads',
   uploadx({
-    directory: './files',
-    maxUploadSize: '10GB',
-    allowMIME: ['video/*'],
+    uploadDir: './files',
+    maxFileSize: '10GB',
+    allowedMimeTypes: ['video/*'],
     onComplete: file => console.log('Upload complete: ', file)
   })
 );
@@ -65,22 +65,22 @@ The `uploadx` function accepts either a storage instance or storage options:
 import { uploadx, DiskStorage } from '@uploadx/core';
 
 // Option 1: Pass storage instance
-const storage = new DiskStorage({ directory: './uploads' });
+const storage = new DiskStorage({ uploadDir: './uploads' });
 app.use('/files', uploadx(storage));
 
 // Option 2: Pass options directly (creates storage automatically)
-app.use('/files', uploadx({ directory: './uploads', maxUploadSize: '10GB' }));
+app.use('/files', uploadx({ uploadDir: './uploads', maxFileSize: '10GB' }));
 ```
 
 ### Storage Options
 
-- `directory` DiskStorage upload directory. Default value: `"files"`
+- `uploadDir` DiskStorage upload directory. Default value: `"files"`
 
-- `path` Node http base path. Default value: `"/files"`
+- `basePath` Node http base path. Default value: `"/files"`
 
-- `allowMIME` Allowed MIME types. Default value: `["*/*"]`
+- `allowedMimeTypes` Allowed MIME types. Default value: `["*/*"]`
 
-- `maxUploadSize` File size limit. Default value: `"5TB"`
+- `maxFileSize` File size limit. Default value: `"5TB"`
 
 - `metaStorage` Provide custom meta storage
 
@@ -94,7 +94,7 @@ app.use('/files', uploadx({ directory: './uploads', maxUploadSize: '10GB' }));
 
 - `baseUrl` Base URL for upload endpoints. If not provided, it is determined from the request.
 
-- `filename` File naming function
+- `namingFunction` File naming function
 
 - `userIdentifier` Get user identity
 
@@ -112,13 +112,25 @@ app.use('/files', uploadx({ directory: './uploads', maxUploadSize: '10GB' }));
 
 - `logLevel` Set built-in logger severity level. Default value: `"none"`
 
+### Deprecated Options
+
+These old names still work but are deprecated:
+
+| Old             | New                |
+| --------------- | ------------------ |
+| `directory`     | `uploadDir`        |
+| `path`          | `basePath`         |
+| `allowMIME`     | `allowedMimeTypes` |
+| `maxUploadSize` | `maxFileSize`      |
+| `filename`      | `namingFunction`   |
+
 ## Storage providers
 
-By default, `uploadx` uses DiskStorage (local filesystem) — just set the `directory` option. For cloud or S3‑compatible storage, install the corresponding package and pass a `storage` instance to the middleware.
+By default, `uploadx` uses DiskStorage (local filesystem) — just set the `uploadDir` option. For cloud or S3‑compatible storage, install the corresponding package and pass a `storage` instance to the middleware.
 
 | Provider             | Package                                    | Description                             |
 | -------------------- | ------------------------------------------ | --------------------------------------- |
-| Local filesystem     | [`@uploadx/core`](packages/core/README.md) | Built-in. Saves files to `directory`.   |
+| Local filesystem     | [`@uploadx/core`](packages/core/README.md) | Built-in. Saves files to `uploadDir`.   |
 | AWS S3 / compatible  | [`@uploadx/s3`](packages/s3/README.md)     | Amazon S3, Backblaze B2 S3, MinIO, etc. |
 | Google Cloud Storage | [`@uploadx/gcs`](packages/gcs/README.md)   | GCS buckets.                            |
 

--- a/examples/express-basic.ts
+++ b/examples/express-basic.ts
@@ -6,10 +6,10 @@ const PORT = process.env.PORT || 3002;
 const app = express();
 
 const uploads = uploadx({
-  directory: process.env.UPLOAD_DIR || 'upload',
-  maxUploadSize: '5GB',
-  allowMIME: ['video/*', 'image/*'],
-  filename: file => file.originalName,
+  uploadDir: process.env.UPLOAD_DIR || 'upload',
+  maxFileSize: '5GB',
+  allowedMimeTypes: ['video/*', 'image/*'],
+  namingFunction: file => file.originalName,
   expiration: { maxAge: '1h', purgeInterval: '10min' },
   onComplete: file => {
     console.log('File upload complete: ', file.originalName);

--- a/examples/express-gcs.ts
+++ b/examples/express-gcs.ts
@@ -7,7 +7,7 @@ const app = express();
 
 const storage = new GCStorage({
   bucket: 'my-bucket',
-  maxUploadSize: '5GB',
+  maxFileSize: '5GB',
   onComplete: ({ uri = 'unknown', id }) => {
     console.log(`File upload complete, storage path: ${uri}`);
     // send gcs link to client

--- a/examples/express-logtape.ts
+++ b/examples/express-logtape.ts
@@ -26,11 +26,11 @@ async function startApp() {
   });
 
   const uploads = uploadx({
-    directory: process.env.UPLOAD_DIR || 'upload',
-    maxUploadSize: '5GB',
-    allowMIME: ['video/*', 'image/*'],
+    uploadDir: process.env.UPLOAD_DIR || 'upload',
+    maxFileSize: '5GB',
+    allowedMimeTypes: ['video/*', 'image/*'],
     useRelativeLocation: true,
-    filename: file => file.originalName,
+    namingFunction: file => file.originalName,
     expiration: { maxAge: '1h', purgeInterval: '10min' }
   });
 

--- a/examples/express-polling.ts
+++ b/examples/express-polling.ts
@@ -12,7 +12,7 @@ const destinationDir = 'files';
 mkdir(destinationDir, { recursive: true }).catch(console.error);
 
 const storage = new DiskStorage({
-  directory: uploadDir,
+  uploadDir: uploadDir,
   expiration: { maxAge: '1h', purgeInterval: '10min' }
 });
 const upload = new Uploadx({ storage }).upload;

--- a/examples/express-s3.ts
+++ b/examples/express-s3.ts
@@ -19,7 +19,7 @@ const app = express();
 // The credentials are loaded from a environment
 const storage = new S3Storage({
   bucket: 'my-bucket',
-  maxUploadSize: '5TB',
+  maxFileSize: '5TB',
   logLevel: <LogLevel>process.env.LOG_LEVEL || 'info',
   onComplete: file => console.log('File upload complete: ', file)
 });

--- a/examples/express-tus.ts
+++ b/examples/express-tus.ts
@@ -5,9 +5,9 @@ const PORT = process.env.PORT || 3002;
 
 const app = express();
 const opts: DiskStorageOptions = {
-  maxUploadSize: '5GB',
-  allowMIME: ['image/*', 'video/*'],
-  directory: process.env.UPLOAD_DIR || 'upload'
+  maxFileSize: '5GB',
+  allowedMimeTypes: ['image/*', 'video/*'],
+  uploadDir: process.env.UPLOAD_DIR || 'upload'
 };
 
 app.use('/files', tus.upload(opts), (req, res) => {

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -23,8 +23,8 @@ const onComplete: express.RequestHandler = (req, res, next) => {
 app.use(
   '/files',
   uploadx.upload({
-    maxUploadSize: '5GB',
-    directory: process.env.UPLOAD_DIR || 'upload',
+    maxFileSize: '5GB',
+    uploadDir: process.env.UPLOAD_DIR || 'upload',
     expiration: { maxAge: '1h', purgeInterval: '10min' },
     userIdentifier: (req: AuthRequest) => (req.user ? `${req.user.id}-${req.user.email}` : ''),
     logLevel: <LogLevel>process.env.LOG_LEVEL || 'info',

--- a/examples/gcs-direct.ts
+++ b/examples/gcs-direct.ts
@@ -10,9 +10,9 @@ const corsHandler = cors();
 // Don't forget to set GCS_BUCKET and GCS_KEYFILE environment variables
 const storage = new GCStorage({
   clientDirectUpload: true,
-  maxUploadSize: '5GB',
-  allowMIME: ['video/*', 'image/*'],
-  filename: file => file.originalName,
+  maxFileSize: '5GB',
+  allowedMimeTypes: ['video/*', 'image/*'],
+  namingFunction: file => file.originalName,
   metaStorage: new MetaStorage()
 });
 

--- a/examples/node-http-server.js
+++ b/examples/node-http-server.js
@@ -7,10 +7,10 @@ const PORT = process.env.PORT || 3002;
 const corsHandler = cors();
 
 const storage = new DiskStorage({
-  directory: process.env.UPLOAD_DIR || 'upload',
-  path: '/files',
-  maxUploadSize: '5GB',
-  allowMIME: ['video/*', 'image/*']
+  uploadDir: process.env.UPLOAD_DIR || 'upload',
+  basePath: '/files',
+  maxFileSize: '5GB',
+  allowedMimeTypes: ['video/*', 'image/*']
 });
 
 const uploadx = new Uploadx({ storage });

--- a/examples/s3-direct.ts
+++ b/examples/s3-direct.ts
@@ -7,8 +7,8 @@ const app = express();
 
 // The credentials are loaded from a shared credentials file or environment variables
 const storage = new S3Storage({
-  maxUploadSize: '5GB',
-  allowMIME: ['image/*', 'video/*'],
+  maxFileSize: '5GB',
+  allowedMimeTypes: ['image/*', 'video/*'],
   bucket: 'my-bucket',
   requestChecksumCalculation: 'WHEN_REQUIRED', // remove useless crc32 checksum headers
   forcePathStyle: true,

--- a/examples/server.js
+++ b/examples/server.js
@@ -8,10 +8,10 @@ const path = '/files';
 const pathRegexp = new RegExp(`^${path}([/?]|$)`);
 
 const config = {
-  path,
-  directory: process.env.UPLOAD_DIR || 'upload',
-  allowMIME: process.env.ALLOW_MIME?.split(',') || ['video/*', 'image/*'],
-  maxUploadSize: process.env.MAX_UPLOAD_SIZE || '2GB',
+  basePath: path,
+  uploadDir: process.env.UPLOAD_DIR || 'upload',
+  allowedMimeTypes: process.env.ALLOW_MIME?.split(',') || ['video/*', 'image/*'],
+  maxFileSize: process.env.MAX_UPLOAD_SIZE || '2GB',
   expiration: { maxAge: process.env.MAX_AGE || '1h', purgeInterval: '10min' },
   logLevel: /** @type { 'info' } */ (process.env.LOG_LEVEL || 'info')
 };

--- a/examples/validation.ts
+++ b/examples/validation.ts
@@ -22,7 +22,7 @@ const onComplete: OnComplete<DiskFile, UploadxResponse<OnCompleteBody>> = file =
 };
 
 const storage = new DiskStorage({
-  directory: process.env.UPLOAD_DIR || 'upload',
+  uploadDir: process.env.UPLOAD_DIR || 'upload',
   onComplete,
   expiration: { maxAge: '1h', purgeInterval: '10min' },
   validation: {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,8 +19,8 @@ const app = express();
 app.use(
   '/files',
   uploadx({
-    directory: './uploads',
-    maxUploadSize: '10GB',
+    uploadDir: './uploads',
+    maxFileSize: '10GB',
     onComplete: file => console.log('Upload complete:', file)
   })
 );

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -245,7 +245,7 @@ export abstract class BaseHandler<TFile extends UploadxFile>
     const pathname = url.parse(req.url as string).pathname || '';
     const path = req.originalUrl
       ? `/${pathname}`.replace('//', '')
-      : `/${pathname}`.replace(`/${this.storage.path}/`, '');
+      : `/${pathname}`.replace(`/${this.storage.basePath}/`, '');
     return path.startsWith('/') ? '' : path;
   }
 

--- a/packages/core/src/handlers/multipart.ts
+++ b/packages/core/src/handlers/multipart.ts
@@ -60,7 +60,7 @@ export class Multipart<TFile extends UploadxFile> extends BaseHandler<TFile> {
  * Basic express wrapper
  * @example
  * ```ts
- * app.use('/files', multipart({directory: '/tmp', maxUploadSize: '250GB'}));
+ * app.use('/files', multipart({uploadDir: '/tmp', maxFileSize: '250GB'}));
  * ```
  */
 export function multipart<TFile extends UploadxFile>(

--- a/packages/core/src/handlers/tus.ts
+++ b/packages/core/src/handlers/tus.ts
@@ -37,7 +37,7 @@ export class Tus<TFile extends UploadxFile> extends BaseHandler<TFile> {
   async options(req: IncomingMessage, res: ServerResponse): Promise<TFile> {
     const headers = {
       'Tus-Extension': this.extension.toString(),
-      'Tus-Max-Size': this.storage.maxUploadSize,
+      'Tus-Max-Size': this.storage.maxFileSize,
       'Tus-Checksum-Algorithm': this.storage.checksumTypes.toString()
     };
     this.send(res, { statusCode: 204, headers });
@@ -141,7 +141,7 @@ export class Tus<TFile extends UploadxFile> extends BaseHandler<TFile> {
  * Basic express wrapper
  * @example
  * ```js
- * app.use('/files', tus({directory: '/tmp', maxUploadSize: '250GB'}));
+ * app.use('/files', tus({uploadDir: '/tmp', maxFileSize: '250GB'}));
  * ```
  */
 export function tus<TFile extends UploadxFile>(

--- a/packages/core/src/handlers/uploadx.ts
+++ b/packages/core/src/handlers/uploadx.ts
@@ -135,7 +135,7 @@ export class Uploadx<TFile extends UploadxFile> extends BaseHandler<TFile> {
  * Basic express wrapper
  * @example
  * ```ts
- * app.use('/files', uploadx({directory: '/tmp', maxUploadSize: '250GB'}));
+ * app.use('/files', uploadx({uploadDir: '/tmp', maxFileSize: '250GB'}));
  * ```
  */
 export function uploadx<TFile extends UploadxFile>(

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -4,9 +4,9 @@ import { BaseStorageOptions } from './storage';
 
 export class ConfigHandler {
   static defaults: BaseStorageOptions<File> = {
-    allowMIME: ['*/*'],
-    maxUploadSize: '5TB',
-    filename: ({ id }: File): string => id,
+    allowedMimeTypes: ['*/*'],
+    maxFileSize: '5TB',
+    namingFunction: ({ id }: File): string => id,
     useRelativeLocation: false,
     baseUrl: getEnv('BASE_URL'),
     onComplete: (file: File) => file,
@@ -18,15 +18,33 @@ export class ConfigHandler {
       const { cause: _c, ...noDetails } = payload;
       return { statusCode, body: { error: noDetails }, headers };
     },
-    path: '/files',
+    basePath: '/files',
     validation: {},
     maxMetadataSize: '4MB'
+  };
+
+  private static aliasMap: Record<string, string> = {
+    allowMIME: 'allowedMimeTypes',
+    filename: 'namingFunction',
+    path: 'basePath',
+    maxUploadSize: 'maxFileSize'
   };
 
   private _config = this.set(ConfigHandler.defaults);
 
   set<T extends File>(config: BaseStorageOptions<T> = {}): Required<BaseStorageOptions<T>> {
-    return Object.assign(this._config ?? {}, config);
+    const normalized = { ...config } as Record<string, unknown>;
+    for (const [oldKey, newKey] of Object.entries(ConfigHandler.aliasMap)) {
+      if (oldKey in normalized) {
+        if (!(newKey in normalized)) {
+          normalized[newKey] = normalized[oldKey];
+        }
+        delete normalized[oldKey];
+      }
+    }
+    return Object.assign(this._config ?? {}, normalized) as unknown as Required<
+      BaseStorageOptions<T>
+    >;
   }
 
   get<T extends File>(): Required<BaseStorageOptions<T>> {

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -32,15 +32,21 @@ export type DiskStorageOptions = BaseStorageOptions<DiskFile> & {
   /**
    * Uploads directory
    * @defaultValue './files'
+   * @deprecated Use {@link uploadDir} instead
    */
   directory?: string;
+  /**
+   * Uploads directory
+   * @defaultValue './files'
+   */
+  uploadDir?: string;
   /**
    * Configuring metafile storage on the local disk
    * @example
    * ```ts
    * const storage = new DiskStorage({
-   *   directory: 'upload',
-   *   metaStorageConfig: { directory: '/tmp/upload-metafiles', prefix: '.' }
+   *   uploadDir: 'upload',
+   *   metaStorageConfig: { uploadDir: '/tmp/upload-metafiles', prefix: '.' }
    * });
    * ```
    */
@@ -57,7 +63,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
 
   constructor(public config: DiskStorageOptions = {}) {
     super(config);
-    this.directory = config.directory || this.path.replace(/^\//, '');
+    this.directory = config.uploadDir ?? (config.directory || this.basePath.replace(/^\//, ''));
     if (config.metaStorage) {
       this.meta = config.metaStorage;
     } else {
@@ -83,7 +89,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
   async create(req: IncomingMessage, fileInit: FileInit): Promise<DiskFile> {
     const file = new DiskFile(fileInit);
     file.name = this.namingFunction(file, req);
-    file.size = Number.isNaN(file.size) ? this.maxUploadSize : file.size;
+    file.size = Number.isNaN(file.size) ? this.maxFileSize : file.size;
     await this.validate(file);
     const path = this.getFilePath(file.name);
     file.bytesWritten = await ensureFile(path).catch(err => fail(ERRORS.FILE_ERROR, err));

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -57,12 +57,27 @@ export interface ExpirationOptions {
 }
 
 export interface BaseStorageOptions<T extends File> {
-  /** Allowed MIME types */
+  /**
+   * Allowed MIME types
+   * @deprecated Use {@link allowedMimeTypes} instead
+   */
   allowMIME?: string[];
-  /** File size limit */
+  /** Allowed MIME types */
+  allowedMimeTypes?: string[];
+  /**
+   * File size limit
+   * @deprecated Use {@link maxFileSize} instead
+   */
   maxUploadSize?: number | string;
-  /** File naming function */
+  /** File size limit */
+  maxFileSize?: number | string;
+  /**
+   * File naming function
+   * @deprecated Use {@link namingFunction} instead
+   */
   filename?: (file: T, req: any) => string;
+  /** File naming function */
+  namingFunction?: (file: T, req: any) => string;
   userIdentifier?: UserIdentifier;
   /** Force relative URI in Location header */
   useRelativeLocation?: boolean;
@@ -79,8 +94,13 @@ export interface BaseStorageOptions<T extends File> {
   onDelete?: OnDelete<T>;
   /** Customize error response */
   onError?: OnError;
-  /** Node http base path */
+  /**
+   * Node http base path
+   * @deprecated Use {@link basePath} instead
+   */
   path?: string;
+  /** Node http base path */
+  basePath?: string;
   /** Upload validation options */
   validation?: Validation<T>;
   /** Limiting the size of custom metadata */
@@ -95,7 +115,7 @@ export interface BaseStorageOptions<T extends File> {
    * app.use(
    *   '/upload',
    *   uploadx.upload({
-   *     directory: 'upload',
+   *     uploadDir: 'upload',
    *     expiration: { maxAge: '6h', purgeInterval: '30min' },
    *     onComplete
    *   })
@@ -116,9 +136,9 @@ export abstract class BaseStorage<TFile extends File> {
   onComplete: (file: TFile) => Promise<UploadxResponse>;
   onDelete: (file: TFile) => Promise<UploadxResponse>;
   onError: (err: HttpError) => UploadxResponse;
-  maxUploadSize: number;
+  maxFileSize: number;
   maxMetadataSize: number;
-  path: string;
+  basePath: string;
   isReady = true;
   checksumTypes: string[] = [];
   errorResponses = {} as ErrorResponses;
@@ -135,14 +155,14 @@ export abstract class BaseStorage<TFile extends File> {
     }
     const configHandler = new ConfigHandler();
     const opts = configHandler.set(config);
-    this.path = opts.path;
+    this.basePath = opts.basePath;
     this.onCreate = normalizeHookResponse(opts.onCreate);
     this.onUpdate = normalizeHookResponse(opts.onUpdate);
     this.onComplete = normalizeHookResponse(opts.onComplete);
     this.onDelete = normalizeHookResponse(opts.onDelete);
     this.onError = normalizeOnErrorResponse(opts.onError);
-    this.namingFunction = opts.filename;
-    this.maxUploadSize = bytes.parse(opts.maxUploadSize);
+    this.namingFunction = opts.namingFunction;
+    this.maxFileSize = bytes.parse(opts.maxFileSize);
     this.maxMetadataSize = bytes.parse(opts.maxMetadataSize);
     this.cache = new Cache(1000, 300);
     this.logger.debug('configuration: {config}', { config });
@@ -152,7 +172,7 @@ export abstract class BaseStorage<TFile extends File> {
     }
 
     const size: Required<ValidatorConfig<TFile>> = {
-      value: this.maxUploadSize,
+      value: this.maxFileSize,
       isValid(file) {
         return file.size <= this.value;
       },
@@ -160,7 +180,7 @@ export abstract class BaseStorage<TFile extends File> {
     };
 
     const mime: Required<ValidatorConfig<TFile>> = {
-      value: opts.allowMIME,
+      value: opts.allowedMimeTypes,
       isValid(file) {
         return !!typeis.is(file.contentType, this.value as string[]);
       },

--- a/packages/gcs/README.md
+++ b/packages/gcs/README.md
@@ -19,8 +19,8 @@ const app = express();
 
 const storage = new GCStorage({
   bucket: 'my-bucket',
-  maxUploadSize: '1GB',
-  allowMIME: ['image/*', 'video/*'],
+  maxFileSize: '1GB',
+  allowedMimeTypes: ['image/*', 'video/*'],
   onComplete: file => console.log('Upload complete:', file)
 });
 

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -89,9 +89,9 @@ export class GCSFile extends File {
  *    keyFile: <PATH_TO_KEY_FILE>,
  *    metaStorage: new MetaStorage(),
  *    clientDirectUpload: true,
- *    maxUploadSize: '15GB',
- *    allowMIME: ['video/*', 'image/*'],
- *    filename: file => file.originalName
+ *    maxFileSize: '15GB',
+ *    allowedMimeTypes: ['video/*', 'image/*'],
+ *    namingFunction: file => file.originalName
  *  });
  * ```
  */

--- a/packages/s3/README.md
+++ b/packages/s3/README.md
@@ -19,8 +19,8 @@ const app = express();
 
 const storage = new S3Storage({
   bucket: 'my-bucket',
-  maxUploadSize: '512MB',
-  allowMIME: ['image/*', 'video/*']
+  maxFileSize: '512MB',
+  allowedMimeTypes: ['image/*', 'video/*']
 });
 
 app.use('/files', uploadx({ storage }));

--- a/test/disk-storage.spec.ts
+++ b/test/disk-storage.spec.ts
@@ -18,7 +18,7 @@ jest.mock('fs');
 describe('DiskStorage', () => {
   jest.useFakeTimers({ doNotFake: ['setTimeout'] }).setSystemTime(new Date('2022-02-02'));
   const directory = 'ds-test';
-  const options = { ...storageOptions, directory };
+  const options = { ...storageOptions, uploadDir: directory };
   let storage: DiskStorage;
   let readStream: RequestReadStream;
   const req = authRequest();

--- a/test/shared/config.ts
+++ b/test/shared/config.ts
@@ -10,9 +10,9 @@ export const userId = 'userId';
 export const testRoot = path.join(tmpdir(), 'files');
 
 export const storageOptions: BaseStorageOptions<File> = {
-  filename: file => `${file.userId || 'anonymous'}/${file.originalName}`,
-  maxUploadSize: '6GB',
-  allowMIME: ['video/*', 'image/*', 'application/octet-stream'],
+  namingFunction: file => `${file.userId || 'anonymous'}/${file.originalName}`,
+  maxFileSize: '6GB',
+  allowedMimeTypes: ['video/*', 'image/*', 'application/octet-stream'],
   useRelativeLocation: true,
   expiration: { maxAge: '1h' }
 };

--- a/test/storage.spec.ts
+++ b/test/storage.spec.ts
@@ -18,8 +18,8 @@ describe('BaseStorage', () => {
     return storage.saveMeta(created);
   }
 
-  it('should set maxUploadSize', () => {
-    expect(storage.maxUploadSize).toBe(5497558138880);
+  it('should set maxFileSize', () => {
+    expect(storage.maxFileSize).toBe(5497558138880);
   });
 
   it('should validate', async () => {


### PR DESCRIPTION
Renamed several BaseStorageOptions/DiskStorageOptions fields for clarity.
Old names work as deprecated aliases.

- `allowMIME` -> `allowedMimeTypes`
- `filename` -> `namingFunction`
- `path` -> `basePath`
- `maxUploadSize` -> `maxFileSize`
- `directory` -> `uploadDir`