### PR TITLE
feat!: explicit fromEnv() call required for env-based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,28 @@ See [express-logtape.ts](examples/express-logtape.ts) for a complete example.
 
 ## Environment Variables
 
-- `UPLOADX_BASE_URL` - Overrides the base URL for upload links.
+Use `fromEnv()` (from `@uploadx/core`) to load configuration from environment variables:
+
+```ts
+import { fromEnv, uploadx } from '@uploadx/core';
+
+app.use('/files', uploadx({ ...fromEnv() }));
+```
+
+| Variable             | Option             | Description                   |
+| -------------------- | ------------------ | ----------------------------- |
+| `BASE_URL`           | `baseUrl`          | Base URL for upload links     |
+| `MAX_FILE_SIZE`      | `maxFileSize`      | File size limit (e.g. `10GB`) |
+| `ALLOWED_MIME_TYPES` | `allowedMimeTypes` | Comma-separated MIME types    |
+| `BASE_PATH`          | `basePath`         | HTTP base path                |
+| `UPLOAD_DIR`         | `uploadDir`        | Upload directory              |
+| `LOG_LEVEL`          | `logLevel`         | Built-in console logger level |
+
+> **Note:** `UPLOADX_SECRET` is read directly from `process.env` and is **not** included in `fromEnv()`.
 
 - `UPLOADX_SECRET` - Secret for salting file/user IDs (set to random string in production).
+
+Variables with a custom prefix (e.g. `MY_APP_UPLOAD_DIR`) are supported by passing the prefix to `fromEnv('MY_APP_')`.
 
 ## Project Structure
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -5,14 +5,14 @@ NODE_ENV=development
 # UPLOADX_SECRET=your-strong-random-secret-here
 LOG_LEVEL=debug
 PORT=3002
-ALLOW_MIME=video/*,image/*
+ALLOWED_MIME_TYPES=video/*,image/*
 UPLOAD_DIR='upload'
 
 # --- Google Cloud Storage ---
 # IMPORTANT: GCS Emulator still requires credentials because google-auth-library needs them
 # Get this from https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?supportedpurview=project
 # GCS_KEYFILE=/path/to/credentials.json
-# GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+#  GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
 
 # GCS Emulator
 # STORAGE_EMULATOR_HOST=localhost:4443
@@ -32,6 +32,5 @@ S3_FORCE_PATH_STYLE=true
 # S3_ENDPOINT (equivalent to AWS_ENDPOINT_URL)
 # S3_ACCESS_KEY (equivalent to AWS_ACCESS_KEY_ID)
 # S3_SECRET_KEY (equivalent to AWS_SECRET_ACCESS_KEY)
-# S3_DEBUG=true
 
 

--- a/examples/express-s3.ts
+++ b/examples/express-s3.ts
@@ -1,6 +1,6 @@
+import { uploadx } from '@uploadx/core';
+import { S3Storage, fromEnv } from '@uploadx/s3';
 import express from 'express';
-import { LogLevel, uploadx } from '@uploadx/core';
-import { S3Storage } from '@uploadx/s3';
 
 const PORT = process.env.PORT || 3002;
 const app = express();
@@ -20,8 +20,12 @@ const app = express();
 const storage = new S3Storage({
   bucket: 'my-bucket',
   maxFileSize: '5TB',
-  logLevel: <LogLevel>process.env.LOG_LEVEL || 'info',
-  onComplete: file => console.log('File upload complete: ', file)
+  ...fromEnv(),
+  onComplete: file => {
+    const message = `File upload complete: ${file.originalName}`;
+    console.log(message);
+    return message;
+  }
 });
 
 app.use('/files', uploadx({ storage }));

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -1,4 +1,4 @@
-import { getLogger, LogLevel, uploadx } from '@uploadx/core';
+import { getLogger, uploadx, fromEnv } from '@uploadx/core';
 import express from 'express';
 
 type AuthRequest = express.Request & { user?: { id: string; email: string } };
@@ -16,24 +16,22 @@ const auth = (req: AuthRequest, res: express.Response, next: express.NextFunctio
 
 app.use(auth);
 
-const onComplete: express.RequestHandler = (req, res, next) => {
-  return res.json(req.body);
-};
-
 app.use(
   '/files',
   uploadx.upload({
     maxFileSize: '5GB',
-    uploadDir: process.env.UPLOAD_DIR || 'upload',
+    uploadDir: './upload',
     expiration: { maxAge: '1h', purgeInterval: '10min' },
     userIdentifier: (req: AuthRequest) => (req.user ? `${req.user.id}-${req.user.email}` : ''),
-    logLevel: <LogLevel>process.env.LOG_LEVEL || 'info',
     onComplete: file => {
       appLogger.info(`File upload complete: ${file.name}`);
       return file;
-    }
+    },
+    ...fromEnv()
   }),
-  onComplete
+  (req, res) => {
+    return res.json(req.body);
+  }
 );
 
 app.listen(PORT, () => appLogger.info('listening on port: {PORT}', { PORT }));

--- a/examples/s3-direct.ts
+++ b/examples/s3-direct.ts
@@ -1,9 +1,10 @@
 import express from 'express';
-import { type LogLevel, uploadx } from '@uploadx/core';
+import { getLogger, uploadx } from '@uploadx/core';
 import { S3Storage } from '@uploadx/s3';
 
 const PORT = process.env.PORT || 3002;
 const app = express();
+const logger = getLogger(['uploadx', 'server']);
 
 // The credentials are loaded from a shared credentials file or environment variables
 const storage = new S3Storage({
@@ -15,9 +16,10 @@ const storage = new S3Storage({
   clientDirectUpload: true, // send presigned urls to the client for upload directly to S3 storage
   partSize: '8MB', // optionally override part size
   expiration: { maxAge: '1h', purgeInterval: '15min' },
-  logLevel: <LogLevel>process.env.LOG_LEVEL || 'info'
+  logLevel: 'error',
+  logger: logger
 });
 
 app.use('/files', uploadx({ storage }));
 
-app.listen(PORT, () => console.log('Listening on port:', PORT));
+app.listen(PORT, () => logger.info('Listening on port: {PORT} ', { PORT }));

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { cors, DiskStorage, Multipart, Tus, Uploadx } = require('@uploadx/core');
+const { cors, DiskStorage, Multipart, Tus, Uploadx, fromEnv } = require('@uploadx/core');
 const { createServer } = require('http');
 const url = require('url');
 
@@ -9,11 +9,11 @@ const pathRegexp = new RegExp(`^${path}([/?]|$)`);
 
 const config = {
   basePath: path,
-  uploadDir: process.env.UPLOAD_DIR || 'upload',
-  allowedMimeTypes: process.env.ALLOW_MIME?.split(',') || ['video/*', 'image/*'],
-  maxFileSize: process.env.MAX_UPLOAD_SIZE || '2GB',
+  uploadDir: './upload',
+  allowedMimeTypes: ['video/*', 'image/*'],
+  maxFileSize: '2GB',
   expiration: { maxAge: process.env.MAX_AGE || '1h', purgeInterval: '10min' },
-  logLevel: /** @type { 'info' } */ (process.env.LOG_LEVEL || 'info')
+  ...fromEnv()
 };
 
 const corsHandler = cors();

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -1,4 +1,4 @@
-import { getEnv, HttpError } from '../utils';
+import { HttpError } from '../utils';
 import { File } from './file';
 import { BaseStorageOptions } from './storage';
 
@@ -8,7 +8,6 @@ export class ConfigHandler {
     maxFileSize: '5TB',
     namingFunction: ({ id }: File): string => id,
     useRelativeLocation: false,
-    baseUrl: getEnv('BASE_URL'),
     onComplete: (file: File) => file,
     onUpdate: (file: File) => file,
     onCreate: () => '',

--- a/packages/core/src/utils/core-env.ts
+++ b/packages/core/src/utils/core-env.ts
@@ -1,10 +1,44 @@
+import { DiskStorageOptions } from '../storages';
+
 const CORE_ENV = {
-  UPLOADX_SECRET: 'UPLOADX_SECRET',
-  BASE_URL: 'UPLOADX_BASE_URL'
+  BASE_URL: 'BASE_URL',
+  MAX_FILE_SIZE: 'MAX_FILE_SIZE',
+  ALLOWED_MIME_TYPES: 'ALLOWED_MIME_TYPES',
+  BASE_PATH: 'BASE_PATH',
+  UPLOAD_DIR: 'UPLOAD_DIR',
+  LOG_LEVEL: 'LOG_LEVEL'
 } as const;
 
-/**
- * Get environment variable by typed key
- */
-export const getEnv = (key: keyof typeof CORE_ENV): string | undefined =>
-  process.env[CORE_ENV[key]];
+type EnvKey = keyof typeof CORE_ENV;
+
+export const DEFAULT_PREFIX = '';
+
+const getEnv = (prefix: string, key: EnvKey): string | undefined => {
+  return process.env[prefix + CORE_ENV[key]];
+};
+
+export const commonFromEnv = (prefix = DEFAULT_PREFIX): Partial<DiskStorageOptions> => {
+  const baseUrl = getEnv(prefix, 'BASE_URL');
+  const maxFileSize = getEnv(prefix, 'MAX_FILE_SIZE');
+  const basePath = getEnv(prefix, 'BASE_PATH');
+  const allowedMimeTypes = getEnv(prefix, 'ALLOWED_MIME_TYPES')
+    ?.split(',')
+    .map(mime => mime.trim())
+    .filter(Boolean);
+  const logLevel = getEnv(prefix, 'LOG_LEVEL') as DiskStorageOptions['logLevel'];
+  return {
+    ...(baseUrl && { baseUrl }),
+    ...(maxFileSize && { maxFileSize }),
+    ...(basePath && { basePath }),
+    ...(allowedMimeTypes?.length && { allowedMimeTypes }),
+    ...(logLevel && { logLevel })
+  };
+};
+
+export const fromEnv = (prefix = DEFAULT_PREFIX): Partial<DiskStorageOptions> => {
+  const uploadDir = getEnv(prefix, 'UPLOAD_DIR');
+  return {
+    ...commonFromEnv(prefix),
+    ...(uploadDir && { uploadDir })
+  };
+};

--- a/packages/core/src/utils/primitives.ts
+++ b/packages/core/src/utils/primitives.ts
@@ -1,9 +1,8 @@
 import { createHash, randomBytes } from 'crypto';
 import { isDeepStrictEqual } from 'util';
 import { Cache } from './cache';
-import { getEnv } from './core-env';
 
-const UPLOADX_SECRET = getEnv('UPLOADX_SECRET') || 'UPLOADX_SECRET';
+const UPLOADX_SECRET = process.env['UPLOADX_SECRET'] || 'UPLOADX_SECRET';
 
 export const pick = <T, K extends keyof T>(obj: T, whitelist: K[]): Pick<T, K> => {
   const result = {} as Pick<T, K>;

--- a/packages/gcs/src/gcs-env.ts
+++ b/packages/gcs/src/gcs-env.ts
@@ -1,0 +1,20 @@
+import { commonFromEnv, DEFAULT_PREFIX } from '@uploadx/core';
+import { GCStorageOptions } from './gcs-storage';
+
+const GCS_ENV = { BUCKET: 'GCS_BUCKET', KEYFILE: 'GCS_KEYFILE' } as const;
+
+type GCSEnvKey = keyof typeof GCS_ENV;
+
+const getGCSEnv = (prefix: string, key: GCSEnvKey): string | undefined => {
+  return process.env[prefix + GCS_ENV[key]];
+};
+
+export const fromEnv = (prefix = DEFAULT_PREFIX): Partial<GCStorageOptions> => {
+  const bucket = getGCSEnv(prefix, 'BUCKET');
+  const keyFile = getGCSEnv(prefix, 'KEYFILE');
+  return {
+    ...commonFromEnv(prefix),
+    ...(bucket && { bucket }),
+    ...(keyFile && { keyFile })
+  };
+};

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -14,8 +14,7 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
 
   constructor(readonly config: GCSMetaStorageOptions = {}) {
     super(config);
-    config.keyFile ||= process.env.GCS_KEYFILE;
-    this.bucket = config.bucket || process.env.GCS_BUCKET || GCSConfig.bucketName;
+    this.bucket = config.bucket || GCSConfig.bucketName;
     this.storageBaseURI = [GCSConfig.storageAPI, this.bucket, 'o'].join('/');
     this.uploadBaseURI = [GCSConfig.uploadAPI, this.bucket, 'o'].join('/');
     config.scopes ||= GCSConfig.authScopes;

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -114,8 +114,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
           : new GCSMetaStorage(metaConfig);
     }
 
-    config.keyFile ||= process.env.GCS_KEYFILE;
-    this.bucket = config.bucket || process.env.GCS_BUCKET || GCSConfig.bucketName;
+    this.bucket = config.bucket || GCSConfig.bucketName;
     this.storageBaseURI = [GCSConfig.storageAPI, this.bucket, 'o'].join('/');
     this.uploadBaseURI = [GCSConfig.uploadAPI, this.bucket, 'o'].join('/');
     config.scopes ||= GCSConfig.authScopes;

--- a/packages/gcs/src/index.ts
+++ b/packages/gcs/src/index.ts
@@ -1,3 +1,4 @@
 export * from './gcs-storage';
 export * from './gcs-meta-storage';
 export * from './gcs-config';
+export * from './gcs-env';

--- a/packages/node-uploadx/src/index.ts
+++ b/packages/node-uploadx/src/index.ts
@@ -1,3 +1,8 @@
 export * from '@uploadx/core';
-export * from '@uploadx/s3';
-export * from '@uploadx/gcs';
+
+export { fromEnv as s3FromEnv, S3MetaStorage, S3Storage } from '@uploadx/s3';
+export type { S3File, S3MetaStorageOptions, S3StorageOptions } from '@uploadx/s3';
+export type { AWSError } from '@uploadx/s3';
+
+export { GCSConfig, fromEnv as gcsFromEnv, GCSMetaStorage, GCStorage } from '@uploadx/gcs';
+export type { GCSFile, GCSMetaStorageOptions, GCStorageOptions } from '@uploadx/gcs';

--- a/packages/s3/README.md
+++ b/packages/s3/README.md
@@ -47,7 +47,6 @@ See `@uploadx/core` and [AWS SDK S3 Client](https://docs.aws.amazon.com/AWSJavaS
 - `S3_FORCE_PATH_STYLE` — Force path-style addressing (for S3-compatible storage)
 - `S3_REGION` — Region
 - `S3_KEYFILE` — Shared credentials file
-- `S3_DEBUG` — Enable S3 client logging (optional, for development)
 
 Standard AWS SDK credential providers are also supported, for example:
 

--- a/packages/s3/src/index.ts
+++ b/packages/s3/src/index.ts
@@ -1,3 +1,4 @@
 export * from './s3-storage';
 export * from './s3-meta-storage';
 export * from './aws-error';
+export * from './s3-env';

--- a/packages/s3/src/s3-env.ts
+++ b/packages/s3/src/s3-env.ts
@@ -1,10 +1,33 @@
-export const S3_ENV = {
+import { commonFromEnv, DEFAULT_PREFIX, toBoolean } from '@uploadx/core';
+import { S3StorageOptions } from './s3-storage';
+
+const S3_ENV = {
   BUCKET: 'S3_BUCKET',
-  KEYFILE: 'S3_KEYFILE',
-  REGION: 'S3_REGION',
   ENDPOINT: 'S3_ENDPOINT',
   FORCE_PATH_STYLE: 'S3_FORCE_PATH_STYLE',
-  DEBUG: 'S3_DEBUG'
+  KEYFILE: 'S3_KEYFILE',
+  REGION: 'S3_REGION'
 } as const;
 
-export const getEnv = (key: keyof typeof S3_ENV): string | undefined => process.env[S3_ENV[key]];
+type S3EnvKey = keyof typeof S3_ENV;
+
+const getS3Env = (prefix: string, key: S3EnvKey): string | undefined => {
+  return process.env[prefix + S3_ENV[key]];
+};
+
+export const fromEnv = (prefix = DEFAULT_PREFIX): Partial<S3StorageOptions> => {
+  const bucket = getS3Env(prefix, 'BUCKET');
+  const keyFile = getS3Env(prefix, 'KEYFILE');
+  const region = getS3Env(prefix, 'REGION');
+  const endpoint = getS3Env(prefix, 'ENDPOINT');
+  const forcePathStyle = getS3Env(prefix, 'FORCE_PATH_STYLE');
+
+  return {
+    ...commonFromEnv(prefix),
+    ...(bucket && { bucket }),
+    ...(keyFile && { keyFile }),
+    ...(region && { region }),
+    ...(endpoint && { endpoint }),
+    ...(forcePathStyle !== undefined && { forcePathStyle: toBoolean(forcePathStyle) })
+  };
+};

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -7,8 +7,7 @@ import {
   S3ClientConfig
 } from '@aws-sdk/client-s3';
 import { fromIni } from '@aws-sdk/credential-providers';
-import { File, MetaStorage, MetaStorageOptions, UploadList, toBoolean } from '@uploadx/core';
-import { getEnv } from './s3-env';
+import { File, MetaStorage, MetaStorageOptions, UploadList } from '@uploadx/core';
 
 const BUCKET_NAME = 'node-uploadx';
 export type S3MetaStorageOptions = S3ClientConfig &
@@ -23,23 +22,11 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
 
   constructor(public config: S3MetaStorageOptions) {
     super(config);
-    this.bucket = config.bucket || getEnv('BUCKET') || BUCKET_NAME;
-    const keyFile = config.keyFile || getEnv('KEYFILE');
-    keyFile && (config.credentials = fromIni({ configFilepath: keyFile }));
-    const clientConfig = { ...config };
-    if (config.forcePathStyle === undefined) {
-      clientConfig.forcePathStyle = toBoolean(getEnv('FORCE_PATH_STYLE'));
+    this.bucket = config.bucket || BUCKET_NAME;
+    if (config.keyFile) {
+      config.credentials = fromIni({ configFilepath: config.keyFile });
     }
-    if (!clientConfig.region) {
-      clientConfig.region = getEnv('REGION');
-    }
-    if (!clientConfig.endpoint) {
-      clientConfig.endpoint = getEnv('ENDPOINT');
-    }
-    clientConfig.logger = toBoolean(getEnv('DEBUG'))
-      ? (this.logger as unknown as S3ClientConfig['logger'])
-      : undefined;
-    this.client = new S3Client(clientConfig);
+    this.client = new S3Client(config);
   }
 
   async get(id: string): Promise<T> {

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -33,7 +33,6 @@ import {
   mapValues,
   MetaStorage,
   partMatch,
-  toBoolean,
   toSeconds,
   updateSize
 } from '@uploadx/core';
@@ -41,7 +40,6 @@ import bytes from 'bytes';
 import { PassThrough } from 'stream';
 import { AWSError } from './aws-error';
 import { S3MetaStorage, S3MetaStorageOptions } from './s3-meta-storage';
-import { getEnv } from './s3-env';
 
 const BUCKET_NAME = 'node-uploadx';
 const MIN_PART_SIZE = 5 * 1024 * 1024;
@@ -128,9 +126,10 @@ export class S3Storage extends BaseStorage<S3File> {
 
   constructor(public config: S3StorageOptions = {}) {
     super(config);
-    this.bucket = config.bucket || getEnv('BUCKET') || BUCKET_NAME;
-    const keyFile = config.keyFile || getEnv('KEYFILE');
-    keyFile && (config.credentials = fromIni({ configFilepath: keyFile }));
+    this.bucket = config.bucket || BUCKET_NAME;
+    if (config.keyFile) {
+      config.credentials = fromIni({ configFilepath: config.keyFile });
+    }
     this._partSize = bytes.parse(this.config.partSize || PART_SIZE);
     if (this._partSize < MIN_PART_SIZE) {
       throw new Error('Minimum allowed partSize value is 5MB');
@@ -139,16 +138,6 @@ export class S3Storage extends BaseStorage<S3File> {
       this.onCreate = async file => ({ body: file }); // TODO: remove hook
     }
     const clientConfig = { ...config };
-    if (config.forcePathStyle === undefined) {
-      clientConfig.forcePathStyle = toBoolean(getEnv('FORCE_PATH_STYLE'));
-    }
-    if (!clientConfig.region) {
-      clientConfig.region = getEnv('REGION');
-    }
-    if (!clientConfig.endpoint) {
-      clientConfig.endpoint = getEnv('ENDPOINT');
-    }
-    clientConfig.logger = toBoolean(getEnv('DEBUG')) ? this.logger : undefined;
     this.client = new S3Client(clientConfig);
     if (config.metaStorage) {
       this.meta = config.metaStorage;

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -265,4 +265,47 @@ describe('utils', () => {
       });
     });
   });
+
+  describe('fromEnv', () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should read env vars without prefix (default)', () => {
+      process.env['BASE_URL'] = 'https://example.com';
+      process.env['UPLOAD_DIR'] = '/uploads';
+      process.env['MAX_FILE_SIZE'] = '10MB';
+      const result = utils.fromEnv();
+      expect(result).toEqual({
+        baseUrl: 'https://example.com',
+        uploadDir: '/uploads',
+        maxFileSize: '10MB'
+      });
+    });
+
+    it('should read custom prefix', () => {
+      process.env['MY_APP_BASE_URL'] = 'https://custom.com';
+      process.env['MY_APP_UPLOAD_DIR'] = '/data';
+      const result = utils.fromEnv('MY_APP_');
+      expect(result).toEqual({
+        baseUrl: 'https://custom.com',
+        uploadDir: '/data'
+      });
+    });
+
+    it('should return empty object when no env vars', () => {
+      const result = utils.fromEnv();
+      expect(result).toEqual({});
+    });
+
+    it('should parse ALLOWED_MIME_TYPES as array', () => {
+      process.env['ALLOWED_MIME_TYPES'] = 'image/png,  image/jpeg ,  video/mp4';
+      const result = utils.fromEnv();
+      expect(result).toEqual({
+        allowedMimeTypes: ['image/png', 'image/jpeg', 'video/mp4']
+      });
+    });
+  });
 });


### PR DESCRIPTION

Storage constructors no longer read `process.env` automatically.
Env‑based configuration must now be loaded explicitly via `fromEnv()`.

Migration:
```ts
// Before (no longer works)
const storage = new S3Storage();
// After
import { fromEnv } from '@uploadx/s3';
const storage = new S3Storage({ bucket: 'my-bucket', ...fromEnv() });
// Same for core options
import { fromEnv, uploadx } from '@uploadx/core';
app.use('/files', uploadx({ ...fromEnv() }));
```
**BREAKING CHANGE**: automatic loading of uploadx env vars removed; AWS_/GOOGLE_* behavior unaffected.