### PR TITLE
refactor(core): replace HttpError with UploadxErrorResponse, add generic type params

### DIFF
--- a/examples/custom-error-responses.ts
+++ b/examples/custom-error-responses.ts
@@ -1,0 +1,38 @@
+import express from 'express';
+import { DiskStorage, uploadx } from 'node-uploadx';
+
+const PORT = process.env.PORT || 3002;
+
+const app = express();
+
+const storage = new DiskStorage({
+  uploadDir: process.env.UPLOAD_DIR || 'upload',
+  maxFileSize: '1GB',
+  logLevel: 'debug',
+  onError(response) {
+    const { code, message } = response;
+    const page = (code || 'unknownerror').toLowerCase();
+    const documentation_url = `http://example.com/api/v1/docs/upload/error/${page}`;
+    const body = { message, documentation_url };
+    return { ...response, body };
+  }
+});
+
+storage.errorResponses = {
+  FileNotFound: {
+    statusCode: 404,
+    code: 'FileNotFound',
+    message: 'Not Found!'
+  },
+  RequestEntityTooLarge: {
+    statusCode: 413,
+    code: 'RequestEntityTooLarge',
+    message: 'Request entity too large'
+  }
+};
+
+app.use('/files', uploadx({ storage }));
+
+app.listen(PORT, () => {
+  console.log('listening on port:', PORT);
+});

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,6 +13,7 @@
     "s3:direct": "tsnd -r tsconfig-paths/register -r dotenv/config s3-direct",
     "tus": "tsnd -r tsconfig-paths/register -r dotenv/config express-tus",
     "validation": "tsnd -r tsconfig-paths/register -r dotenv/config validation",
+    "custom-error-responses": "tsnd -r tsconfig-paths/register -r dotenv/config custom-error-responses",
     "plain-nodejs": "tsnd -r dotenv/config node-http-server",
     "server": "tsnd -r dotenv/config server"
   },

--- a/examples/validation.ts
+++ b/examples/validation.ts
@@ -5,12 +5,7 @@ const PORT = process.env.PORT || 3002;
 
 const app = express();
 
-type OnCompleteBody = {
-  message: string;
-  id: string;
-};
-
-const onComplete: OnComplete<DiskFile, UploadxResponse<OnCompleteBody>> = file => {
+const onComplete: OnComplete<DiskFile, UploadxResponse> = file => {
   const message = `File upload is finished, path: ${file.name}`;
   console.log(message);
   return {
@@ -27,10 +22,10 @@ const storage = new DiskStorage({
   expiration: { maxAge: '1h', purgeInterval: '10min' },
   validation: {
     mime: { value: ['video/*'], response: [415, { message: 'video only' }] },
-    size: {
+    size2: {
       isValid(file) {
-        this.response = [412, { message: `The file size(${file.size}) is larger than 5GiB` }];
-        return file.size <= 5368709120;
+        this.response = [412, { message: `The file size (${file.size}) is larger than 1GiB` }];
+        return file.size <= 1024 * 1024 * 1024;
       }
     },
     mtime: {

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -23,13 +23,12 @@ import {
   fail,
   getBaseUrl,
   isUploadxError,
-  isValidationError,
   Logger,
   pick,
-  uploadxLogger,
   setHeaders,
   tokenize,
-  UploadxError
+  UploadxError,
+  uploadxLogger
 } from '../utils';
 import { Cors } from './cors';
 
@@ -79,8 +78,6 @@ export abstract class BaseHandler<TFile extends UploadxFile>
   storage: BaseStorage<TFile>;
   registeredHandlers = new Map<string, AsyncHandler>();
   logger: Logger;
-  protected _errorResponses = {} as ErrorResponses;
-
   constructor(config: UploadxOptions<TFile> = {}) {
     super();
     this.cors = new Cors();
@@ -92,22 +89,11 @@ export abstract class BaseHandler<TFile extends UploadxFile>
       this.getUserId = config.userIdentifier;
     }
     this.logger = uploadxLogger.getChild(this.constructor.name);
-    this.assembleErrors();
     this.compose();
   }
 
-  /**
-   *  Override error responses
-   *  @example
-   * ```ts
-   *  const uploadx = new Uploadx({ storage });
-   *  uploadx.errorResponses = {
-   *    FileNotFound: [404, { message: 'Not Found!' }]
-   *  }
-   * ```
-   */
   set errorResponses(value: Partial<ErrorResponses>) {
-    this.assembleErrors(value);
+    Object.assign(this.storage.errorResponses, value);
   }
 
   compose(): void {
@@ -118,15 +104,6 @@ export abstract class BaseHandler<TFile extends UploadxFile>
       // handler && this.cors.allowedMethods.push(method.toUpperCase());
     });
     this.logger.debug(`Registered handlers: ${[...this.registeredHandlers.keys()].join(', ')}`);
-  }
-
-  assembleErrors(customErrors = {}): void {
-    this._errorResponses = {
-      ...ErrorMap,
-      ...this._errorResponses,
-      ...this.storage.errorResponses,
-      ...customErrors
-    };
   }
 
   handle = (req: IncomingMessage, res: ServerResponse): void => this.upload(req, res);
@@ -140,10 +117,10 @@ export abstract class BaseHandler<TFile extends UploadxFile>
     this.logger.debug('Request {method} {url}', { method: req.method, url: req.url });
     const handler = this.registeredHandlers.get(req.method as string);
     if (!handler) {
-      return this.sendError(res, { uploadxErrorCode: ERRORS.METHOD_NOT_ALLOWED } as UploadxError);
+      return this.sendError(res, new UploadxError(ERRORS.METHOD_NOT_ALLOWED));
     }
     if (!this.storage.isReady) {
-      return this.sendError(res, { uploadxErrorCode: ERRORS.STORAGE_ERROR } as UploadxError);
+      return this.sendError(res, new UploadxError(ERRORS.STORAGE_ERROR));
     }
 
     handler(req, res)
@@ -171,24 +148,19 @@ export abstract class BaseHandler<TFile extends UploadxFile>
         }
         if (req.method === 'GET') {
           (req as IncomingMessageWithBody)['body'] = file;
-          next ? next() : this.send(res, { body: file });
+          next ? next() : this.send(res, { statusCode: 200, body: file });
         }
         return;
       })
       .catch((error: Error) => {
-        const keys = Object.getOwnPropertyNames(error) as (keyof Error)[];
-        const sanitizedError = pick(error, [
-          'name',
-          ...(isUploadxError(error) ? keys.filter(k => k !== 'stack') : keys)
-        ]) as UploadxError;
         const errorPayload = {
-          ...sanitizedError,
+          ...pick(error, Object.getOwnPropertyNames(error) as (keyof Error)[]),
           request: pick(req, ['headers', 'method', 'url'])
         };
-        this.listenerCount('error') && this.emit('error', errorPayload);
+        this.listenerCount('error') && this.emit('error', errorPayload as UploadxErrorEvent);
         this.logger.error('{errorPayload.message} {*}', { errorPayload });
         if ('aborted' in req && req['aborted']) return;
-        return this.sendError(res, sanitizedError);
+        return this.sendError(res, error);
       });
   };
 
@@ -228,13 +200,23 @@ export abstract class BaseHandler<TFile extends UploadxFile>
   /**
    * Send Error to client
    */
-  sendError(res: ServerResponse, error: Error): void {
-    const httpError = isUploadxError(error)
-      ? { ...this._errorResponses[error.uploadxErrorCode], cause: error.cause }
-      : isValidationError(error)
-        ? error
-        : this.storage.normalizeError(error);
-    const response = this.storage.onError(httpError);
+  sendError(res: ServerResponse, error: unknown): void {
+    let info;
+    if (isUploadxError(error)) {
+      info = this.storage.errorResponses[error.uploadxErrorCode] ??
+        ErrorMap[error.uploadxErrorCode as ERRORS] ?? {
+          code: error.uploadxErrorCode,
+          message: error.message,
+          statusCode: 500,
+          cause: error.cause
+        };
+    } else {
+      info = this.storage.normalizeError(error);
+    }
+    const response = { ...this.storage.onError(info) };
+    if (!response.body) {
+      response.body = { error: { code: info.code, message: info.message } };
+    }
     this.send(res, response);
   }
 

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -2,7 +2,7 @@ import { UploadxErrorResponse } from '../utils';
 import { File } from './file';
 import { BaseStorageOptions } from './storage';
 
-export class ConfigHandler {
+export class ConfigHandler<T extends File = File> {
   static defaults: BaseStorageOptions<File> = {
     allowedMimeTypes: ['*/*'],
     maxFileSize: '5TB',
@@ -25,9 +25,9 @@ export class ConfigHandler {
     maxUploadSize: 'maxFileSize'
   };
 
-  private _config = this.set(ConfigHandler.defaults);
+  private _config = { ...ConfigHandler.defaults } as BaseStorageOptions<T>;
 
-  set<T extends File>(config: BaseStorageOptions<T> = {}): Required<BaseStorageOptions<T>> {
+  set(config: Partial<BaseStorageOptions<T>> = {}): Required<BaseStorageOptions<T>> {
     const normalized = { ...config } as Record<string, unknown>;
     for (const [oldKey, newKey] of Object.entries(ConfigHandler.aliasMap)) {
       if (oldKey in normalized) {
@@ -37,12 +37,11 @@ export class ConfigHandler {
         delete normalized[oldKey];
       }
     }
-    return Object.assign(this._config ?? {}, normalized) as unknown as Required<
-      BaseStorageOptions<T>
-    >;
+    this._config = { ...this._config, ...normalized };
+    return this._config as Required<BaseStorageOptions<T>>;
   }
 
-  get<T extends File>(): Required<BaseStorageOptions<T>> {
-    return this._config as unknown as Required<BaseStorageOptions<T>>;
+  get(): BaseStorageOptions<T> {
+    return this._config;
   }
 }

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -1,4 +1,4 @@
-import { HttpError } from '../utils';
+import { UploadxErrorResponse } from '../utils';
 import { File } from './file';
 import { BaseStorageOptions } from './storage';
 
@@ -12,11 +12,7 @@ export class ConfigHandler {
     onUpdate: (file: File) => file,
     onCreate: () => '',
     onDelete: () => '',
-    onError: ({ statusCode, body, headers, cause, ...rest }: HttpError) => {
-      const payload = (body || rest) as Record<string, unknown>;
-      const { cause: _c, ...noDetails } = payload;
-      return { statusCode, body: { error: noDetails }, headers };
-    },
+    onError: (response: UploadxErrorResponse) => response,
     basePath: '/files',
     validation: {},
     maxMetadataSize: '4MB'

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -6,11 +6,11 @@ import {
   ERRORS,
   fail,
   getWriteStream,
-  HttpError,
   removeFile,
   streamChecksum,
   streamLength,
-  truncateFile
+  truncateFile,
+  UploadxErrorResponse
 } from '../utils';
 import {
   File,
@@ -78,7 +78,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
       });
   }
 
-  normalizeError(err: Error): HttpError {
+  normalizeError(err: Error): UploadxErrorResponse {
     return super.normalizeError(err);
   }
 

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -8,15 +8,13 @@ import {
   ErrorResponses,
   ERRORS,
   fail,
-  HttpError,
-  HttpErrorBody,
   isEqual,
   Logger,
   LogLevel,
   normalizeHookResponse,
-  normalizeOnErrorResponse,
   toMilliseconds,
   typeis,
+  UploadxErrorResponse,
   uploadxLogger,
   validateTimerInterval,
   Validation,
@@ -37,7 +35,7 @@ export type OnComplete<TFile extends File, TBody = any> = (file: TFile) => Promi
 
 export type OnDelete<TFile extends File, TBody = any> = (file: TFile) => Promise<TBody> | TBody;
 
-export type OnError<TBody = HttpErrorBody> = (error: HttpError<TBody>) => any;
+export type OnError = (error: UploadxErrorResponse) => UploadxResponse;
 
 export type PurgeList = UploadList & { maxAgeMs: number };
 
@@ -135,7 +133,7 @@ export abstract class BaseStorage<TFile extends File> {
   onUpdate: (file: TFile) => Promise<UploadxResponse>;
   onComplete: (file: TFile) => Promise<UploadxResponse>;
   onDelete: (file: TFile) => Promise<UploadxResponse>;
-  onError: (err: HttpError) => UploadxResponse;
+  onError: OnError;
   maxFileSize: number;
   maxMetadataSize: number;
   basePath: string;
@@ -160,10 +158,11 @@ export abstract class BaseStorage<TFile extends File> {
     this.onUpdate = normalizeHookResponse(opts.onUpdate);
     this.onComplete = normalizeHookResponse(opts.onComplete);
     this.onDelete = normalizeHookResponse(opts.onDelete);
-    this.onError = normalizeOnErrorResponse(opts.onError);
+    this.onError = opts.onError ?? ((response: UploadxErrorResponse) => response);
     this.namingFunction = opts.namingFunction;
     this.maxFileSize = bytes.parse(opts.maxFileSize);
     this.maxMetadataSize = bytes.parse(opts.maxMetadataSize);
+    this.validation = new Validator<TFile>(undefined, this.errorResponses);
     this.cache = new Cache(1000, 300);
     this.logger.debug('configuration: {config}', { config });
     const purgeInterval = toMilliseconds(opts.expiration?.purgeInterval);
@@ -200,7 +199,7 @@ export abstract class BaseStorage<TFile extends File> {
     return this.validation.verify(file);
   }
 
-  normalizeError(error: Error): HttpError {
+  normalizeError(error: unknown): UploadxErrorResponse {
     return {
       message: 'Generic Uploadx Error',
       statusCode: 500,

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -139,11 +139,11 @@ export abstract class BaseStorage<TFile extends File> {
   basePath: string;
   isReady = true;
   checksumTypes: string[] = [];
-  errorResponses = {} as ErrorResponses;
   cache: Cache<TFile>;
   logger: Logger = uploadxLogger.getChild(this.constructor.name);
+  protected validation;
   protected namingFunction: (file: TFile, req: any) => string;
-  protected validation = new Validator<TFile>();
+  private _errorResponses: ErrorResponses = {};
   abstract meta: MetaStorage<TFile>;
 
   protected constructor(public config: BaseStorageOptions<TFile>) {
@@ -151,7 +151,7 @@ export abstract class BaseStorage<TFile extends File> {
     if (config.logLevel) {
       configureSimpleLogger(config.logLevel);
     }
-    const configHandler = new ConfigHandler();
+    const configHandler = new ConfigHandler<TFile>();
     const opts = configHandler.set(config);
     this.basePath = opts.basePath;
     this.onCreate = normalizeHookResponse(opts.onCreate);
@@ -193,6 +193,14 @@ export abstract class BaseStorage<TFile extends File> {
     };
     this.validation.add({ size, mime, filename });
     this.validation.add({ ...opts.validation });
+  }
+
+  get errorResponses(): ErrorResponses {
+    return this._errorResponses;
+  }
+
+  set errorResponses(value: Partial<ErrorResponses>) {
+    Object.assign(this._errorResponses, value);
   }
 
   async validate(file: TFile): Promise<any> {

--- a/packages/core/src/types/http.ts
+++ b/packages/core/src/types/http.ts
@@ -6,19 +6,18 @@ export type IncomingMessage = http.IncomingMessage & {
 
 export type ServerResponse = http.ServerResponse;
 
-export interface IncomingMessageWithBody<T = any> extends http.IncomingMessage {
+export interface IncomingMessageWithBody<T = unknown> extends http.IncomingMessage {
   body?: T;
   _body?: boolean;
 }
 
 export type Headers = Record<string, number | string | string[]>;
 
-export type ResponseBody = string | Record<string, any>;
 export type ResponseBodyType = 'text' | 'json';
 
-export type ResponseTuple<T = ResponseBody> = [statusCode: number, body?: T, headers?: Headers];
+export type ResponseTuple<T = unknown> = [statusCode: number, body?: T, headers?: Headers];
 
-export interface UploadxResponse<T = ResponseBody> {
+export interface UploadxResponse<T = unknown> {
   statusCode?: number;
   headers?: Headers;
   body?: T;

--- a/packages/core/src/types/http.ts
+++ b/packages/core/src/types/http.ts
@@ -18,7 +18,7 @@ export type ResponseBodyType = 'text' | 'json';
 
 export type ResponseTuple<T = ResponseBody> = [statusCode: number, body?: T, headers?: Headers];
 
-export interface UploadxResponse<T = ResponseBody> extends Record<string, any> {
+export interface UploadxResponse<T = ResponseBody> {
   statusCode?: number;
   headers?: Headers;
   body?: T;

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -1,4 +1,5 @@
-import { UploadxResponse } from '../types';
+import { ResponseTuple, UploadxResponse } from '../types';
+import { isRecord } from './primitives';
 
 export enum ERRORS {
   BAD_REQUEST = 'BadRequest',
@@ -24,8 +25,19 @@ export enum ERRORS {
   REQUEST_ABORTED = 'RequestAborted'
 }
 
+export interface UploadxErrorResponse extends UploadxResponse {
+  [key: string]: unknown;
+  statusCode: number;
+  code?: string;
+  message: string;
+  body?: Record<string, any>;
+  name?: string;
+  retryable?: boolean;
+  cause?: unknown;
+}
+
 export type ErrorResponses<T extends string = string> = {
-  [K in T]: HttpError;
+  [K in T]: UploadxErrorResponse;
 };
 
 class E_ {
@@ -66,16 +78,15 @@ class E_ {
 export const ErrorMap: ErrorResponses<ERRORS> = E_.errors;
 
 export class UploadxError extends Error {
-  uploadxErrorCode: ERRORS = ERRORS.UNKNOWN_ERROR;
+  uploadxErrorCode: string = ERRORS.UNKNOWN_ERROR;
   cause?: unknown;
 
-  constructor(uploadxErrorCode: ERRORS = ERRORS.UNKNOWN_ERROR, message?: string, cause?: unknown) {
+  constructor(uploadxErrorCode: string = ERRORS.UNKNOWN_ERROR, message?: string, cause?: unknown) {
     super(message || uploadxErrorCode);
     this.name = 'UploadxError';
     this.cause = cause;
-    if (Object.values(ERRORS).includes(uploadxErrorCode)) {
-      this.uploadxErrorCode = uploadxErrorCode;
-    }
+    this.uploadxErrorCode = uploadxErrorCode;
+    delete this.stack;
   }
 }
 
@@ -83,21 +94,20 @@ export function isUploadxError(err: unknown): err is UploadxError {
   return !!(err as UploadxError)?.uploadxErrorCode;
 }
 
+export function normalizeErrorResponse(
+  response: ResponseTuple | UploadxErrorResponse
+): UploadxErrorResponse {
+  if (!Array.isArray(response)) {
+    const { statusCode = 500, headers, ...rest } = response;
+    return { ...rest, statusCode, headers } as UploadxErrorResponse;
+  }
+  const [statusCode, body = {}, headers] = response;
+  const b = isRecord(body) ? body : { message: body as string };
+  return { ...b, statusCode, headers } as UploadxErrorResponse;
+}
+
 export function fail(uploadxErrorCode: ERRORS, cause?: unknown): Promise<never> {
   const entry = ErrorMap[uploadxErrorCode];
-  const message = (entry as { message?: string })?.message;
+  const message = entry?.message;
   return Promise.reject(new UploadxError(uploadxErrorCode, message, cause));
-}
-
-export interface HttpErrorBody {
-  message: string;
-  code: string;
-  uploadxErrorCode?: string;
-  name?: string;
-  retryable?: boolean;
-  cause?: Record<string, any> | string;
-}
-
-export interface HttpError<T = HttpErrorBody> extends UploadxResponse<T> {
-  statusCode: number;
 }

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -1,12 +1,6 @@
 import http from 'http';
 import { getLastOne, isRecord } from './primitives';
-import {
-  Headers,
-  IncomingMessageWithBody,
-  ResponseBody,
-  ResponseTuple,
-  UploadxResponse
-} from '../types/http';
+import { Headers, IncomingMessageWithBody, ResponseTuple, UploadxResponse } from '../types/http';
 import { UploadxFile } from '../storages';
 
 export const typeis = (req: http.IncomingMessage, types: string[]): string | false => {
@@ -49,20 +43,20 @@ export function readBody(
  * @param req - incoming metadata request
  * @param limit - optional limit on the size of the body
  */
-export async function getJsonBody(
+export async function getJsonBody<T = Record<string, any>>(
   req: IncomingMessageWithBody<Record<any, any>>,
   limit = 16777216
-): Promise<Record<any, any>> {
+): Promise<T> {
   if (typeis(req, ['json'])) {
-    if (req.body) return { ...req.body };
+    if (req.body) return { ...req.body } as T;
     const contentLength = typeis.hasBody(req);
     if (contentLength) {
       if (contentLength > limit) return Promise.reject('Content length limit exceeded');
       const raw = await readBody(req, 'utf8', contentLength);
-      return { ...JSON.parse(raw) } as Record<any, any>;
+      return { ...JSON.parse(raw) } as T;
     }
   }
-  return {} as Record<any, any>;
+  return {} as T;
 }
 
 /**
@@ -127,18 +121,14 @@ function extractProto(req: http.IncomingMessage & { protocol?: string }): string
   return req.protocol || getHeader(req, 'x-forwarded-proto').toLowerCase();
 }
 
-export function responseToTuple<T extends ResponseBody>(
-  response: UploadxResponse<T> | ResponseTuple<T>
-): ResponseTuple {
+export function responseToTuple(response: UploadxResponse | ResponseTuple): ResponseTuple {
   if (Array.isArray(response)) return response;
   const { statusCode = 200, headers, ...rest } = response;
   const body = response.body ? response.body : rest;
   return [statusCode, body, headers || {}];
 }
 
-export function tupleToResponse<T extends ResponseBody>(
-  response: ResponseTuple<T> | UploadxResponse<T>
-): UploadxResponse {
+export function tupleToResponse(response: ResponseTuple | UploadxResponse): UploadxResponse {
   if (!Array.isArray(response)) return response;
   const [statusCode, body, headers] = response;
   return { statusCode, body, headers };

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -1,5 +1,4 @@
 import http from 'http';
-import { HttpError, HttpErrorBody } from './errors';
 import { getLastOne, isRecord } from './primitives';
 import {
   Headers,
@@ -150,22 +149,13 @@ export function normalizeHookResponse<T>(fn: (file: T) => Promise<UploadxRespons
     const response = await fn(file);
     if (isRecord(response)) {
       const { statusCode, headers, body, ...rest } = response;
-      return { statusCode, headers, body: body ?? rest };
+      return {
+        statusCode: typeof statusCode === 'number' ? statusCode : 200,
+        headers: (isRecord(headers) ? headers : {}) as Headers,
+        body: body ?? rest
+      };
     }
     return { body: response ?? '' };
-  };
-}
-
-/*
-@internal
- */
-export function normalizeOnErrorResponse(fn: (error: HttpError) => UploadxResponse) {
-  return (error: HttpError) => {
-    if (isRecord(error)) {
-      const { statusCode, headers, body, ...rest } = error;
-      return fn({ statusCode, headers, body: body ?? (rest as HttpErrorBody) });
-    }
-    return fn({ body: error ?? 'unknown error', statusCode: 500 });
   };
 }
 

--- a/packages/core/src/utils/validator.ts
+++ b/packages/core/src/utils/validator.ts
@@ -1,35 +1,46 @@
-import { ErrorMap, HttpError } from './errors';
-import { tupleToResponse } from './http';
 import { ResponseTuple } from '../types';
+import {
+  ErrorMap,
+  ErrorResponses,
+  normalizeErrorResponse,
+  UploadxError,
+  UploadxErrorResponse
+} from './errors';
 
 export interface ValidatorConfig<T> {
   value?: any;
   isValid?: (t: T) => boolean | Promise<boolean>;
-  response?: ResponseTuple<any> | HttpError<any>;
+  response?: ResponseTuple | UploadxErrorResponse;
 }
 
 const capitalize = (s: string): string => s && s[0].toUpperCase() + s.slice(1);
 export type Validation<T> = Record<string, ValidatorConfig<T>>;
 
-export interface ValidationError extends HttpError {
-  name: 'ValidationError';
-}
-
-export function isValidationError(error: unknown): error is ValidationError {
-  return (error as ValidationError).name === 'ValidationError';
-}
-
 export class Validator<T> {
   private _validators: Record<string, Required<ValidatorConfig<T>>> = {};
 
-  constructor(private prefix = 'ValidationError') {}
+  constructor(
+    private prefix = 'ValidationError',
+    private errorResponses?: ErrorResponses
+  ) {}
 
   add(config: Validation<T>): void {
     for (const [key, validator] of Object.entries(config)) {
       const code = `${this.prefix}${capitalize(key)}`;
-      this._validators[code] = { ...this._validators[code], ...validator };
+      const v = { ...this._validators[code], ...validator };
+      if (!v.response) {
+        v.response = ErrorMap.UnprocessableEntity;
+      }
+      this._validators[code] = v;
       if (typeof this._validators[code].isValid !== 'function') {
         throw new Error('Validation config "isValid" is missing, or it is not a function!');
+      }
+      if (this.errorResponses) {
+        const r = normalizeErrorResponse(v.response);
+        r.code ??= code;
+        if (!(r.code in ErrorMap)) {
+          this.errorResponses[r.code] = r;
+        }
       }
     }
   }
@@ -37,11 +48,12 @@ export class Validator<T> {
   async verify(t: T): Promise<void> {
     for (const [code, validator] of Object.entries(this._validators)) {
       if (!(await validator.isValid(t))) {
-        return Promise.reject({
-          name: 'ValidationError',
-          code,
-          ...tupleToResponse(validator.response || ErrorMap.UnprocessableEntity)
-        });
+        const r = normalizeErrorResponse(validator.response);
+        r.code ??= code;
+        if (this.errorResponses && !(r.code in ErrorMap)) {
+          this.errorResponses[r.code] = r;
+        }
+        return Promise.reject(new UploadxError(r.code, r.message));
       }
     }
   }

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -10,13 +10,13 @@ import {
   getFileStatus,
   getHeader,
   hasContent,
-  HttpError,
   IncomingMessage,
   LocalMetaStorage,
   LocalMetaStorageOptions,
   mapValues,
   MetaStorage,
-  partMatch
+  partMatch,
+  UploadxErrorResponse
 } from '@uploadx/core';
 import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
 import { GCSConfig } from './gcs-config';
@@ -126,7 +126,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
       .catch(error => this.logger.error('Storage access check failed: {error.message}', { error }));
   }
 
-  normalizeError(error: ClientError): HttpError {
+  normalizeError(error: ClientError): UploadxErrorResponse {
     const statusCode = +error.code || 500;
     if (error.config) {
       return {

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -26,7 +26,6 @@ import {
   FileQuery,
   getFileStatus,
   hasContent,
-  HttpError,
   IncomingMessage,
   LocalMetaStorage,
   LocalMetaStorageOptions,
@@ -34,7 +33,8 @@ import {
   MetaStorage,
   partMatch,
   toSeconds,
-  updateSize
+  updateSize,
+  UploadxErrorResponse
 } from '@uploadx/core';
 import bytes from 'bytes';
 import { PassThrough } from 'stream';
@@ -135,7 +135,7 @@ export class S3Storage extends BaseStorage<S3File> {
       throw new Error('Minimum allowed partSize value is 5MB');
     }
     if (this.config.clientDirectUpload) {
-      this.onCreate = async file => ({ body: file }); // TODO: remove hook
+      this.onCreate = async file => ({ statusCode: 200, body: file }); // TODO: remove hook
     }
     const clientConfig = { ...config };
     this.client = new S3Client(clientConfig);
@@ -154,7 +154,7 @@ export class S3Storage extends BaseStorage<S3File> {
       .catch(error => this.logger.error('Storage access check failed: {error.message}', { error }));
   }
 
-  normalizeError(error: AWSError): HttpError {
+  normalizeError(error: AWSError): UploadxErrorResponse {
     if (error.$metadata) {
       return {
         message: error.message,

--- a/test/__snapshots__/disk-storage.spec.ts.snap
+++ b/test/__snapshots__/disk-storage.spec.ts.snap
@@ -1,13 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`DiskStorage .create() should reject on limits 1`] = `
-{
-  "code": "RequestEntityTooLarge",
-  "message": "Request entity too large",
-  "name": "ValidationError",
-  "statusCode": 413,
-}
-`;
+exports[`DiskStorage .create() should reject on limits 1`] = `[UploadxError: Request entity too large]`;
 
 exports[`DiskStorage .create() should set status and bytesWritten 1`] = `
 DiskFile {

--- a/test/base-handler.spec.ts
+++ b/test/base-handler.spec.ts
@@ -1,6 +1,6 @@
+import * as http from 'http';
 import { createRequest, createResponse } from 'node-mocks-http';
 import { testStorage, TestUploader } from './shared';
-import * as http from 'http';
 
 describe('BaseHandler', () => {
   let uploader: TestUploader;
@@ -66,6 +66,8 @@ describe('BaseHandler', () => {
           code: 'GenericUploadxError'
         }
       },
+      code: 'GenericUploadxError',
+      message: 'Generic Uploadx Error',
       headers: undefined
     });
   });

--- a/test/errors.spec.ts
+++ b/test/errors.spec.ts
@@ -1,9 +1,10 @@
 import {
-  ERRORS,
   ErrorMap,
-  UploadxError,
+  ERRORS,
   fail,
-  isUploadxError
+  isUploadxError,
+  normalizeErrorResponse,
+  UploadxError
 } from '../packages/core/src/utils/errors';
 
 describe('errors', () => {
@@ -56,6 +57,39 @@ describe('errors', () => {
     it('should store cause', async () => {
       const cause = 'test cause';
       await expect(fail(ERRORS.BAD_REQUEST, cause)).rejects.toHaveProperty('cause', cause);
+    });
+  });
+
+  describe('normalizeErrorResponse', () => {
+    it('should convert tuple with body object', () => {
+      const response: [number, Record<string, any>] = [415, { message: 'video only' }];
+      const result = normalizeErrorResponse(response);
+
+      expect(result.statusCode).toBe(415);
+      expect(result.message).toBe('video only');
+    });
+
+    it('should convert tuple with body string and headers', () => {
+      const response: [number, string, Record<string, string>] = [
+        415,
+        'video only',
+        { 'content-type': 'text/plain' }
+      ];
+      const result = normalizeErrorResponse(response);
+
+      expect(result.statusCode).toBe(415);
+      expect(result.message).toBe('video only');
+      expect(result.headers).toEqual({ 'content-type': 'text/plain' });
+    });
+
+    it('should default to statusCode 500 for object without statusCode', () => {
+      const response = { code: 'TestError', message: 'test message' };
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      const result = normalizeErrorResponse(response as any);
+
+      expect(result.statusCode).toBe(500);
+      expect(result.code).toBe('TestError');
+      expect(result.message).toBe('test message');
     });
   });
 });

--- a/test/storage.spec.ts
+++ b/test/storage.spec.ts
@@ -28,7 +28,7 @@ describe('BaseStorage', () => {
 
   it('should validate error', async () => {
     await expect(storage.validate({ ...metafile, name: '../file.ext' })).rejects.toHaveProperty(
-      'statusCode'
+      'uploadxErrorCode'
     );
   });
 

--- a/test/uploadx.spec.ts
+++ b/test/uploadx.spec.ts
@@ -21,10 +21,12 @@ describe('::Uploadx', () => {
       onCreate: () => 'created',
       onUpdate: () => 'updated',
       onComplete: () => 'completed',
-      onError: ({ statusCode, body }) => {
-        const errors = [{ status: statusCode, title: body?.code, detail: body?.message }];
+      onError: response => {
+        const errors = [
+          { status: response.statusCode, title: response.code, detail: response.message }
+        ];
         return {
-          statusCode,
+          statusCode: response.statusCode,
           headers: { 'Content-Type': 'application/vnd.api+json' },
           body: { errors }
         };
@@ -321,7 +323,7 @@ describe('::Uploadx', () => {
         .send({ ...file2, size: 10e10 })
         .expect(413);
       expect(event).toHaveProperty('request.method', 'POST');
-      expect(event).toHaveProperty('code', 'RequestEntityTooLarge');
+      expect(event).toHaveProperty('uploadxErrorCode', 'RequestEntityTooLarge');
     });
   });
 });

--- a/test/validator.spec.ts
+++ b/test/validator.spec.ts
@@ -3,9 +3,10 @@ import { Validator } from '../packages/core/src';
 describe('Validator', () => {
   type TestObj = { prop: number };
   let validation: Validator<TestObj>;
-  const responses = {};
+  let responses: Record<string, any>;
 
   beforeEach(() => {
+    responses = {};
     validation = new Validator<TestObj>(undefined, responses);
   });
 

--- a/test/validator.spec.ts
+++ b/test/validator.spec.ts
@@ -3,9 +3,10 @@ import { Validator } from '../packages/core/src';
 describe('Validator', () => {
   type TestObj = { prop: number };
   let validation: Validator<TestObj>;
+  const responses = {};
 
   beforeEach(() => {
-    validation = new Validator<TestObj>();
+    validation = new Validator<TestObj>(undefined, responses);
   });
 
   it('simple', async () => {
@@ -16,10 +17,8 @@ describe('Validator', () => {
       }
     });
     await expect(validation.verify(obj)).rejects.toMatchObject({
-      code: 'UnprocessableEntity',
-      message: 'Validation failed',
-      name: 'ValidationError',
-      statusCode: 422
+      uploadxErrorCode: 'UnprocessableEntity',
+      name: 'UploadxError'
     });
   });
 
@@ -31,10 +30,8 @@ describe('Validator', () => {
       }
     });
     await expect(validation.verify(obj)).rejects.toMatchObject({
-      code: 'UnprocessableEntity',
-      message: 'Validation failed',
-      name: 'ValidationError',
-      statusCode: 422
+      uploadxErrorCode: 'UnprocessableEntity',
+      name: 'UploadxError'
     });
   });
 
@@ -43,15 +40,12 @@ describe('Validator', () => {
     validation.add({
       custom: {
         isValid: p => p.prop > 20,
-        response: [400, 'error']
+        response: { code: 'ValidationErrorCustom', statusCode: 400, message: 'error' }
       }
     });
     await expect(validation.verify(obj)).rejects.toMatchObject({
-      body: 'error',
-      code: 'ValidationErrorCustom',
-      headers: undefined,
-      name: 'ValidationError',
-      statusCode: 400
+      uploadxErrorCode: 'ValidationErrorCustom',
+      name: 'UploadxError'
     });
   });
 
@@ -62,15 +56,26 @@ describe('Validator', () => {
         isValid(p) {
           return p.prop > 20;
         },
-        response: { statusCode: 400, body: 'error' }
+        response: { statusCode: 400, message: 'error' }
       }
     });
     await expect(validation.verify(obj)).rejects.toMatchObject({
-      body: 'error',
-      code: 'ValidationErrorCustom',
-      // headers: undefined,
-      name: 'ValidationError',
-      statusCode: 400
+      uploadxErrorCode: 'ValidationErrorCustom',
+      name: 'UploadxError'
+    });
+  });
+
+  it('tuple with body object', async () => {
+    const obj = { prop: 10 };
+    validation.add({
+      custom: {
+        isValid: p => p.prop > 20,
+        response: [415, { message: 'video only' }]
+      }
+    });
+    await expect(validation.verify(obj)).rejects.toMatchObject({
+      uploadxErrorCode: 'ValidationErrorCustom',
+      name: 'UploadxError'
     });
   });
 
@@ -82,18 +87,15 @@ describe('Validator', () => {
         isValid(p) {
           this.response = {
             statusCode: 400,
-            body: `prop: ${p.prop} less value: ${this.value as number}`
+            message: `prop: ${p.prop} less value: ${this.value as number}`
           };
           return p.prop > this.value;
         }
       }
     });
     await expect(validation.verify(obj)).rejects.toMatchObject({
-      body: 'prop: 10 less value: 20',
-      code: 'ValidationErrorCustom',
-      //FIXME:  headers: undefined,
-      name: 'ValidationError',
-      statusCode: 400
+      uploadxErrorCode: 'ValidationErrorCustom',
+      name: 'UploadxError'
     });
   });
 
@@ -101,7 +103,7 @@ describe('Validator', () => {
     expect(() => {
       validation.add({
         custom: {
-          response: [400, 'error']
+          response: { code: 'test', statusCode: 400, message: 'error' }
         }
       });
     }).toThrow();


### PR DESCRIPTION
- Replace `HttpError`/`HttpErrorBody` types with unified `UploadxErrorResponse`.

BREAKING CHANGE: remove `HttpError`, `HttpErrorBody`, `ValidationError`,
`isValidationError`; `OnError` receives `UploadxErrorResponse` instead of `HttpError`