### PR TITLE
refactor: rename `config` param to `options` and simplify hook types

### DIFF
--- a/examples/validation.ts
+++ b/examples/validation.ts
@@ -1,11 +1,11 @@
 import express from 'express';
-import { DiskFile, DiskStorage, OnComplete, uploadx, UploadxResponse } from 'node-uploadx';
+import { DiskStorage, type OnComplete, uploadx } from 'node-uploadx';
 
 const PORT = process.env.PORT || 3002;
 
 const app = express();
 
-const onComplete: OnComplete<DiskFile, UploadxResponse> = file => {
+const onComplete: OnComplete = file => {
   const message = `File upload is finished, path: ${file.name}`;
   console.log(message);
   return {

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -103,7 +103,7 @@ export abstract class BaseHandler<TFile extends UploadxFile>
       handler && this.registeredHandlers.set(method.toUpperCase(), handler.bind(this));
       // handler && this.cors.allowedMethods.push(method.toUpperCase());
     });
-    this.logger.debug(`Registered handlers: ${[...this.registeredHandlers.keys()].join(', ')}`);
+    this.logger.debug(`registered handlers: ${[...this.registeredHandlers.keys()].join(', ')}`);
   }
 
   handle = (req: IncomingMessage, res: ServerResponse): void => this.upload(req, res);

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -78,15 +78,15 @@ export abstract class BaseHandler<TFile extends UploadxFile>
   storage: BaseStorage<TFile>;
   registeredHandlers = new Map<string, AsyncHandler>();
   logger: Logger;
-  constructor(config: UploadxOptions<TFile> = {}) {
+  constructor(options: UploadxOptions<TFile> = {}) {
     super();
     this.cors = new Cors();
     this.storage =
-      'storage' in config
-        ? config.storage
-        : (new DiskStorage(config) as unknown as BaseStorage<TFile>);
-    if (config.userIdentifier) {
-      this.getUserId = config.userIdentifier;
+      'storage' in options
+        ? options.storage
+        : (new DiskStorage(options) as unknown as BaseStorage<TFile>);
+    if (options.userIdentifier) {
+      this.getUserId = options.userIdentifier;
     }
     this.logger = uploadxLogger.getChild(this.constructor.name);
     this.compose();

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -61,13 +61,13 @@ export class DiskStorage extends BaseStorage<DiskFile> {
   directory: string;
   meta: MetaStorage<DiskFile>;
 
-  constructor(public config: DiskStorageOptions = {}) {
-    super(config);
-    this.directory = config.uploadDir ?? (config.directory || this.basePath.replace(/^\//, ''));
-    if (config.metaStorage) {
-      this.meta = config.metaStorage;
+  constructor(public options: DiskStorageOptions = {}) {
+    super(options);
+    this.directory = options.uploadDir ?? (options.directory || this.basePath.replace(/^\//, ''));
+    if (options.metaStorage) {
+      this.meta = options.metaStorage;
     } else {
-      const metaConfig = { ...config, ...config.metaStorageConfig };
+      const metaConfig = { ...options, ...options.metaStorageConfig };
       this.meta = new LocalMetaStorage(metaConfig);
     }
     this.isReady = false;

--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -17,9 +17,9 @@ export interface LocalMetaStorageOptions extends MetaStorageOptions {
 export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
   readonly directory: string;
 
-  constructor(config?: LocalMetaStorageOptions) {
-    super(config);
-    this.directory = (config?.directory || join(tmpdir(), 'uploadx_meta')).replace(/\\/g, '/');
+  constructor(options?: LocalMetaStorageOptions) {
+    super(options);
+    this.directory = (options?.directory || join(tmpdir(), 'uploadx_meta')).replace(/\\/g, '/');
     this.accessCheck().catch(err => {
       this.logger.error('Metadata storage access check failed: {err}', { err });
     });

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -30,9 +30,9 @@ export class MetaStorage<T> {
   suffix = '';
   logger: Logger = uploadxLogger.getChild(this.constructor.name);
 
-  constructor(config?: MetaStorageOptions) {
-    this.prefix = config?.prefix || '';
-    this.suffix = config?.suffix || METAFILE_EXTNAME;
+  constructor(options?: MetaStorageOptions) {
+    this.prefix = options?.prefix || '';
+    this.suffix = options?.suffix || METAFILE_EXTNAME;
     this.prefix && FileName.INVALID_PREFIXES.push(this.prefix);
     this.suffix && FileName.INVALID_SUFFIXES.push(this.suffix);
   }

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -170,7 +170,7 @@ export abstract class BaseStorage<TFile extends File> {
     this.validation = new Validator<TFile>(undefined, this.errorResponses);
 
     this.cache = new Cache(1000, 300);
-    this.logger.debug('configuration: {options}', { options });
+    this.logger.debug('provided options: {options}', { options });
     const purgeInterval = toMilliseconds(this.config.expiration?.purgeInterval);
     if (purgeInterval) {
       this.startAutoPurge(purgeInterval);

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -25,16 +25,19 @@ import { ConfigHandler } from './config';
 import { File, FileInit, FileName, FilePart, FileQuery, isExpired, updateMetadata } from './file';
 import { MetaStorage, UploadList } from './meta-storage';
 
+/** Returns a unique user identifier.*/
 export type UserIdentifier = (req: any, res: any) => string;
 
-export type OnCreate<TFile extends File, TBody = any> = (file: TFile) => Promise<TBody> | TBody;
+/** Called when a new upload is created. Return value sent as response; use `UploadxResponse` for full control. */
+export type OnCreate<T extends File = File> = (file: T) => unknown;
+/** Called when an upload is updated. Return value sent as response; use `UploadxResponse` for full control. */
+export type OnUpdate<T extends File = File> = (file: T) => unknown;
+/** Called when an upload is completed. Return value sent as response; use `UploadxResponse` for full control. */
+export type OnComplete<T extends File = File> = (file: T) => unknown;
+/** Called when an upload is cancelled. Return value sent as response; use `UploadxResponse` for full control. */
+export type OnDelete<T extends File = File> = (file: T) => unknown;
 
-export type OnUpdate<TFile extends File, TBody = any> = (file: TFile) => Promise<TBody> | TBody;
-
-export type OnComplete<TFile extends File, TBody = any> = (file: TFile) => Promise<TBody> | TBody;
-
-export type OnDelete<TFile extends File, TBody = any> = (file: TFile) => Promise<TBody> | TBody;
-
+/** Called on upload errors. Return `UploadxResponse` to override the default error response. */
 export type OnError = (error: UploadxErrorResponse) => UploadxResponse;
 
 export type PurgeList = UploadList & { maxAgeMs: number };
@@ -76,21 +79,22 @@ export interface BaseStorageOptions<T extends File> {
   filename?: (file: T, req: any) => string;
   /** File naming function */
   namingFunction?: (file: T, req: any) => string;
+  /** Returns a unique user identifier.*/
   userIdentifier?: UserIdentifier;
   /** Force relative URI in Location header */
   useRelativeLocation?: boolean;
 
   /** Base URL for upload endpoints. If not provided, it is determined from the request. */
   baseUrl?: string | ((req: any) => string);
-  /** Callback function that is called when a new upload is created */
+  /** Called when a new upload is created */
   onCreate?: OnCreate<T>;
-  /** Callback function that is called when an upload is updated */
+  /** Called when an upload is updated */
   onUpdate?: OnUpdate<T>;
-  /** Callback function that is called when an upload is completed */
+  /** Called when an upload is completed */
   onComplete?: OnComplete<T>;
-  /** Callback function that is called when an upload is cancelled */
+  /** Called when an upload is cancelled */
   onDelete?: OnDelete<T>;
-  /** Customize error response */
+  /** Called on upload errors. Return `UploadxResponse` to override the default error response. */
   onError?: OnError;
   /**
    * Node http base path

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -145,27 +145,29 @@ export abstract class BaseStorage<TFile extends File> {
   protected namingFunction: (file: TFile, req: any) => string;
   private _errorResponses: ErrorResponses = {};
   abstract meta: MetaStorage<TFile>;
+  public config: Required<BaseStorageOptions<TFile>>;
 
-  protected constructor(public config: BaseStorageOptions<TFile>) {
+  protected constructor(public options: BaseStorageOptions<TFile>) {
     // Configure the logger if a logLevel is specified
-    if (config.logLevel) {
-      configureSimpleLogger(config.logLevel);
+    if (options.logLevel) {
+      configureSimpleLogger(options.logLevel);
     }
     const configHandler = new ConfigHandler<TFile>();
-    const opts = configHandler.set(config);
-    this.basePath = opts.basePath;
-    this.onCreate = normalizeHookResponse(opts.onCreate);
-    this.onUpdate = normalizeHookResponse(opts.onUpdate);
-    this.onComplete = normalizeHookResponse(opts.onComplete);
-    this.onDelete = normalizeHookResponse(opts.onDelete);
-    this.onError = opts.onError ?? ((response: UploadxErrorResponse) => response);
-    this.namingFunction = opts.namingFunction;
-    this.maxFileSize = bytes.parse(opts.maxFileSize);
-    this.maxMetadataSize = bytes.parse(opts.maxMetadataSize);
+    this.config = configHandler.set(options);
+    this.basePath = this.config.basePath;
+    this.onCreate = normalizeHookResponse(this.config.onCreate);
+    this.onUpdate = normalizeHookResponse(this.config.onUpdate);
+    this.onComplete = normalizeHookResponse(this.config.onComplete);
+    this.onDelete = normalizeHookResponse(this.config.onDelete);
+    this.onError = this.config.onError ?? ((response: UploadxErrorResponse) => response);
+    this.namingFunction = this.config.namingFunction;
+    this.maxFileSize = bytes.parse(this.config.maxFileSize);
+    this.maxMetadataSize = bytes.parse(this.config.maxMetadataSize);
     this.validation = new Validator<TFile>(undefined, this.errorResponses);
+
     this.cache = new Cache(1000, 300);
-    this.logger.debug('configuration: {config}', { config });
-    const purgeInterval = toMilliseconds(opts.expiration?.purgeInterval);
+    this.logger.debug('configuration: {options}', { options });
+    const purgeInterval = toMilliseconds(this.config.expiration?.purgeInterval);
     if (purgeInterval) {
       this.startAutoPurge(purgeInterval);
     }
@@ -179,7 +181,7 @@ export abstract class BaseStorage<TFile extends File> {
     };
 
     const mime: Required<ValidatorConfig<TFile>> = {
-      value: opts.allowedMimeTypes,
+      value: this.config.allowedMimeTypes,
       isValid(file) {
         return !!typeis.is(file.contentType, this.value as string[]);
       },
@@ -192,7 +194,7 @@ export abstract class BaseStorage<TFile extends File> {
       response: ErrorMap.InvalidFileName
     };
     this.validation.add({ size, mime, filename });
-    this.validation.add({ ...opts.validation });
+    this.validation.add({ ...this.config.validation });
   }
 
   get errorResponses(): ErrorResponses {

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -134,7 +134,7 @@ export function tupleToResponse(response: ResponseTuple | UploadxResponse): Uplo
   return { statusCode, body, headers };
 }
 
-export function normalizeHookResponse<T>(fn: (file: T) => Promise<UploadxResponse>) {
+export function normalizeHookResponse<T>(fn: (file: T) => unknown) {
   return async (file: T) => {
     const response = await fn(file);
     if (isRecord(response)) {

--- a/packages/gcs/src/gcs-meta-storage.ts
+++ b/packages/gcs/src/gcs-meta-storage.ts
@@ -12,13 +12,13 @@ export class GCSMetaStorage<T extends File = File> extends MetaStorage<T> {
   uploadBaseURI: string;
   bucket: string;
 
-  constructor(readonly config: GCSMetaStorageOptions = {}) {
-    super(config);
-    this.bucket = config.bucket || GCSConfig.bucketName;
+  constructor(readonly options: GCSMetaStorageOptions = {}) {
+    super(options);
+    this.bucket = options.bucket || GCSConfig.bucketName;
     this.storageBaseURI = [GCSConfig.storageAPI, this.bucket, 'o'].join('/');
     this.uploadBaseURI = [GCSConfig.uploadAPI, this.bucket, 'o'].join('/');
-    config.scopes ||= GCSConfig.authScopes;
-    this.authClient = new GoogleAuth(config);
+    options.scopes ||= GCSConfig.authScopes;
+    this.authClient = new GoogleAuth(options);
   }
 
   /**

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -102,23 +102,23 @@ export class GCStorage extends BaseStorage<GCSFile> {
   uploadBaseURI: string;
   meta: MetaStorage<GCSFile>;
 
-  constructor(public config: GCStorageOptions = {}) {
-    super(config);
-    if (config.metaStorage) {
-      this.meta = config.metaStorage;
+  constructor(public options: GCStorageOptions = {}) {
+    super(options);
+    if (options.metaStorage) {
+      this.meta = options.metaStorage;
     } else {
-      const metaConfig = { ...config, ...config.metaStorageConfig };
+      const metaConfig = { ...options, ...options.metaStorageConfig };
       this.meta =
         'directory' in metaConfig
           ? new LocalMetaStorage(metaConfig)
           : new GCSMetaStorage(metaConfig);
     }
 
-    this.bucket = config.bucket || GCSConfig.bucketName;
+    this.bucket = options.bucket || GCSConfig.bucketName;
     this.storageBaseURI = [GCSConfig.storageAPI, this.bucket, 'o'].join('/');
     this.uploadBaseURI = [GCSConfig.uploadAPI, this.bucket, 'o'].join('/');
-    config.scopes ||= GCSConfig.authScopes;
-    this.authClient = new GoogleAuth(config);
+    options.scopes ||= GCSConfig.authScopes;
+    this.authClient = new GoogleAuth(options);
 
     this.isReady = false;
     this.accessCheck()
@@ -167,7 +167,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
     };
     const res = await this.authClient.request(opts);
     file.uri = res.headers.get('location') as string;
-    if (this.config.clientDirectUpload) {
+    if (this.options.clientDirectUpload) {
       file.GCSUploadURI = file.uri;
       this.logger.debug('Send uploadURI to client', { uri: file.GCSUploadURI });
       file.status = 'created';

--- a/packages/s3/src/s3-meta-storage.ts
+++ b/packages/s3/src/s3-meta-storage.ts
@@ -20,13 +20,13 @@ export class S3MetaStorage<T extends File = File> extends MetaStorage<T> {
   bucket: string;
   client: S3Client;
 
-  constructor(public config: S3MetaStorageOptions) {
-    super(config);
-    this.bucket = config.bucket || BUCKET_NAME;
-    if (config.keyFile) {
-      config.credentials = fromIni({ configFilepath: config.keyFile });
+  constructor(public options: S3MetaStorageOptions) {
+    super(options);
+    this.bucket = options.bucket || BUCKET_NAME;
+    if (options.keyFile) {
+      options.credentials = fromIni({ configFilepath: options.keyFile });
     }
-    this.client = new S3Client(config);
+    this.client = new S3Client(options);
   }
 
   async get(id: string): Promise<T> {

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -124,25 +124,25 @@ export class S3Storage extends BaseStorage<S3File> {
   checksumTypes = ['md5'];
   private readonly _partSize = PART_SIZE;
 
-  constructor(public config: S3StorageOptions = {}) {
-    super(config);
-    this.bucket = config.bucket || BUCKET_NAME;
-    if (config.keyFile) {
-      config.credentials = fromIni({ configFilepath: config.keyFile });
+  constructor(public options: S3StorageOptions = {}) {
+    super(options);
+    this.bucket = options.bucket || BUCKET_NAME;
+    if (options.keyFile) {
+      options.credentials = fromIni({ configFilepath: options.keyFile });
     }
-    this._partSize = bytes.parse(this.config.partSize || PART_SIZE);
+    this._partSize = bytes.parse(this.options.partSize || PART_SIZE);
     if (this._partSize < MIN_PART_SIZE) {
       throw new Error('Minimum allowed partSize value is 5MB');
     }
-    if (this.config.clientDirectUpload) {
+    if (this.options.clientDirectUpload) {
       this.onCreate = async file => ({ statusCode: 200, body: file }); // TODO: remove hook
     }
-    const clientConfig = { ...config };
+    const clientConfig = { ...options };
     this.client = new S3Client(clientConfig);
-    if (config.metaStorage) {
-      this.meta = config.metaStorage;
+    if (options.metaStorage) {
+      this.meta = options.metaStorage;
     } else {
-      const metaConfig = { ...config, ...config.metaStorageConfig };
+      const metaConfig = { ...options, ...options.metaStorageConfig };
       this.meta =
         'directory' in metaConfig
           ? new LocalMetaStorage(metaConfig)
@@ -182,7 +182,7 @@ export class S3Storage extends BaseStorage<S3File> {
       Key: file.name,
       ContentType: file.contentType,
       Metadata: mapValues(file.metadata, encodeURI),
-      ACL: this.config.acl
+      ACL: this.options.acl
     };
     const { UploadId } = await this.client.send(new CreateMultipartUploadCommand(params));
     if (!UploadId) {
@@ -190,12 +190,12 @@ export class S3Storage extends BaseStorage<S3File> {
     }
     file.UploadId = UploadId;
     file.bytesWritten = 0;
-    if (this.config.clientDirectUpload) {
+    if (this.options.clientDirectUpload) {
       file.partSize ??= this._partSize;
     }
     await this.saveMeta(file);
     file.status = 'created';
-    if (this.config.clientDirectUpload) return this.buildPresigned(file);
+    if (this.options.clientDirectUpload) return this.buildPresigned(file);
     return file;
   }
 
@@ -205,7 +205,7 @@ export class S3Storage extends BaseStorage<S3File> {
     if (file.status === 'completed') return file;
     if (part.size) updateSize(file, part.size);
     if (!partMatch(part, file)) return fail(ERRORS.FILE_CONFLICT);
-    if (this.config.clientDirectUpload) return this.buildPresigned(file);
+    if (this.options.clientDirectUpload) return this.buildPresigned(file);
     file.Parts ??= await this._getParts(file);
     file.bytesWritten = file.Parts.map(item => item.Size || 0).reduce((p, c) => p + c, 0);
     if (hasContent(part)) {
@@ -273,7 +273,7 @@ export class S3Storage extends BaseStorage<S3File> {
   }
 
   async update({ id }: FileQuery, metadata: Partial<S3File>): Promise<S3File> {
-    if (this.config.clientDirectUpload) {
+    if (this.options.clientDirectUpload) {
       const file = await this.getMeta(id);
       return this.buildPresigned({ ...file, ...metadata });
     }

--- a/test/shared/uploader.ts
+++ b/test/shared/uploader.ts
@@ -16,8 +16,8 @@ export class TestStorage extends BaseStorage<File> {
   isReady = true;
   meta;
 
-  constructor(config = {} as BaseStorageOptions<File>) {
-    super(config);
+  constructor(options = {} as BaseStorageOptions<File>) {
+    super(options);
     this.meta = new MetaStorage<File>();
   }
 


### PR DESCRIPTION
- `config` -> `options` in all storage constructors and `BaseHandler`
- Hook types (`OnCreate`, `OnUpdate`, etc.) return `unknown` instead of `Promise<TBody> | TBody`
- `BaseStorage.config` now stores resolved config (with defaults applied) instead of raw input
