### PR TITLE
feat(core): add metaDir option to DiskStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ app.use('/files', uploadx({ uploadDir: './uploads', maxFileSize: '10GB' }));
 
 - `uploadDir` DiskStorage upload directory. Default value: `"files"`
 
+- `metaDir` Metadata directory. Overrides `metaStorageConfig.directory`. Defaults to `uploadDir`.
+
 - `basePath` Node http base path. Default value: `"/files"`
 
 - `allowedMimeTypes` Allowed MIME types. Default value: `["*/*"]`
@@ -159,6 +161,7 @@ app.use('/files', uploadx({ ...fromEnv() }));
 | `ALLOWED_MIME_TYPES` | `allowedMimeTypes` | Comma-separated MIME types    |
 | `BASE_PATH`          | `basePath`         | HTTP base path                |
 | `UPLOAD_DIR`         | `uploadDir`        | Upload directory              |
+| `META_DIR`           | `metaDir`          | Metafiles directory           |
 | `LOG_LEVEL`          | `logLevel`         | Built-in console logger level |
 
 > **Note:** `UPLOADX_SECRET` is read directly from `process.env` and is **not** included in `fromEnv()`.

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -41,6 +41,12 @@ export type DiskStorageOptions = BaseStorageOptions<DiskFile> & {
    */
   uploadDir?: string;
   /**
+   * Metafiles storage directory.
+   * Overrides `metaStorageConfig.directory`.
+   * When not set, defaults to `uploadDir`.
+   */
+  metaDir?: string;
+  /**
    * Configuring metafile storage on the local disk
    * @example
    * ```ts
@@ -68,6 +74,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
       this.meta = options.metaStorage;
     } else {
       const metaConfig = { ...options, ...options.metaStorageConfig };
+      metaConfig.directory = options.metaDir ?? metaConfig.directory ?? this.directory;
       this.meta = new LocalMetaStorage(metaConfig);
     }
     this.isReady = false;

--- a/packages/core/src/utils/core-env.ts
+++ b/packages/core/src/utils/core-env.ts
@@ -6,6 +6,7 @@ const CORE_ENV = {
   ALLOWED_MIME_TYPES: 'ALLOWED_MIME_TYPES',
   BASE_PATH: 'BASE_PATH',
   UPLOAD_DIR: 'UPLOAD_DIR',
+  META_DIR: 'META_DIR',
   LOG_LEVEL: 'LOG_LEVEL'
 } as const;
 
@@ -37,8 +38,10 @@ export const commonFromEnv = (prefix = DEFAULT_PREFIX): Partial<DiskStorageOptio
 
 export const fromEnv = (prefix = DEFAULT_PREFIX): Partial<DiskStorageOptions> => {
   const uploadDir = getEnv(prefix, 'UPLOAD_DIR');
+  const metaDir = getEnv(prefix, 'META_DIR');
   return {
     ...commonFromEnv(prefix),
-    ...(uploadDir && { uploadDir })
+    ...(uploadDir && { uploadDir }),
+    ...(metaDir && { metaDir })
   };
 };


### PR DESCRIPTION
Adds `metaDir` option to `DiskStorage` for storing metadata files
in a separate directory from uploads. Overrides `metaStorageConfig.directory`.
When not set, defaults to `uploadDir`.

Also adds `META_DIR` environment variable support.
