### PR TITLE
feat(core): add redis meta storage support

### DIFF
--- a/.dev/docker-compose.yml
+++ b/.dev/docker-compose.yml
@@ -81,11 +81,23 @@ services:
         exit 0
     networks:
       - uploadx-network
+  # Redis for testing
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '6379:6379'
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+    networks:
+      - uploadx-network
 
 volumes:
   minio-data:
     driver: local
   gcs-storage:
+    driver: local
+  redis-data:
     driver: local
 
 networks:

--- a/examples/express-redis.ts
+++ b/examples/express-redis.ts
@@ -1,0 +1,23 @@
+import { uploadx, RedisMetaStorage, fromEnv } from '@uploadx/core';
+import express from 'express';
+
+const PORT = process.env.PORT || 3002;
+
+const app = express();
+
+const uploads = uploadx({
+  uploadDir: 'upload',
+  metaStorage: new RedisMetaStorage(),
+  maxFileSize: '5GB',
+  allowedMimeTypes: ['video/*', 'image/*'],
+  expiration: { maxAge: '30min', purgeInterval: '3min' },
+  onComplete: file => {
+    console.log('File upload complete: ', file.originalName);
+    return file;
+  },
+  ...fromEnv()
+});
+
+app.use('/files', uploads);
+
+app.listen(PORT, () => console.log('listening on port:', PORT));

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "basic": "tsnd -r tsconfig-paths/register -r dotenv/config express-basic",
     "express": "tsnd -r tsconfig-paths/register -r dotenv/config express",
+    "redis": "tsnd -r tsconfig-paths/register -r dotenv/config express-redis",
     "express-polling": "tsnd -r tsconfig-paths/register -r dotenv/config express-polling",
     "gcs:direct": "tsnd -r tsconfig-paths/register -r dotenv/config gcs-direct",
     "gcs": "tsnd -r tsconfig-paths/register -r dotenv/config express-gcs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/supertest": "6.0.3",
         "express": "^5.2.1",
         "husky": "9.1.7",
+        "ioredis-mock": "^8.13.1",
         "jest": "30.0.2",
         "lint-staged": "16.1.2",
         "memfs": "^4.17.2",
@@ -2043,6 +2044,20 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@ioredis/as-callback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz",
+      "integrity": "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -5726,6 +5741,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ioredis-mock": {
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/@types/ioredis-mock/-/ioredis-mock-8.2.7.tgz",
+      "integrity": "sha512-YsGiaOIYBKeVvu/7GYziAD8qX3LJem5LK00d5PKykzsQJMLysAqXA61AkNuYWCekYl64tbMTqVOMF4SYoCPbQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "ioredis": ">=5"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -6855,6 +6881,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7066,6 +7102,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -7786,6 +7832,35 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fengari": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
+      "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readline-sync": "^1.4.10",
+        "sprintf-js": "^1.1.3",
+        "tmp": "^0.2.5"
+      }
+    },
+    "node_modules/fengari-interop": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.4.tgz",
+      "integrity": "sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "fengari": "^0.1.0"
+      }
+    },
+    "node_modules/fengari/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -8366,6 +8441,50 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
+      "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis-mock": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.13.1.tgz",
+      "integrity": "sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/as-callback": "^3.0.0",
+        "@ioredis/commands": "^1.4.0",
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.3",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">=12.22"
+      },
+      "peerDependencies": {
+        "@types/ioredis-mock": "^8",
+        "ioredis": "^5"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -12367,6 +12486,39 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -12850,6 +13002,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -13185,6 +13344,16 @@
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -14008,6 +14177,9 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "ioredis": "^5.10.1"
       }
     },
     "packages/gcs": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/supertest": "6.0.3",
     "express": "^5.2.1",
     "husky": "9.1.7",
+    "ioredis-mock": "^8.13.1",
     "jest": "30.0.2",
     "lint-staged": "16.1.2",
     "memfs": "^4.17.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,9 @@
     "bytes": "^3.1.0",
     "multiparty": "^4.3.0"
   },
+  "optionalDependencies": {
+    "ioredis": "^5.10.1"
+  },
   "devDependencies": {
     "@types/bytes": "3.1.1",
     "@types/multiparty": "4.2.1"

--- a/packages/core/src/storages/index.ts
+++ b/packages/core/src/storages/index.ts
@@ -3,4 +3,5 @@ export * from './file';
 export * from './storage';
 export * from './local-meta-storage';
 export * from './meta-storage';
+export * from './redis-meta-storage';
 export * from './config';

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -31,8 +31,8 @@ export class MetaStorage<T> {
   logger: Logger = uploadxLogger.getChild(this.constructor.name);
 
   constructor(options?: MetaStorageOptions) {
-    this.prefix = options?.prefix || '';
-    this.suffix = options?.suffix || METAFILE_EXTNAME;
+    this.prefix = options?.prefix ?? '';
+    this.suffix = options?.suffix ?? METAFILE_EXTNAME;
     this.prefix && FileName.INVALID_PREFIXES.push(this.prefix);
     this.suffix && FileName.INVALID_SUFFIXES.push(this.suffix);
   }

--- a/packages/core/src/storages/redis-meta-storage.ts
+++ b/packages/core/src/storages/redis-meta-storage.ts
@@ -1,0 +1,131 @@
+import type { Redis, RedisOptions } from 'ioredis';
+import { File } from './file';
+import { MetaStorage, MetaStorageOptions, UploadList } from './meta-storage';
+
+/**
+ * Redis connection and metadata storage options
+ */
+export interface RedisMetaStorageOptions extends MetaStorageOptions, RedisOptions {}
+
+let RedisCtor: new (options?: RedisOptions) => Redis;
+
+try {
+  RedisCtor = require('ioredis') as typeof RedisCtor;
+} catch {
+  // ioredis is optional and may not be installed
+}
+
+/**
+ * Redis-backed upload metadata storage
+ * @example
+ * ```ts
+ * import { RedisMetaStorage, uploadx } from '@uploadx/core';
+ *
+ * app.use(
+ *   '/files',
+ *   uploadx({
+ *     uploadDir: 'upload',
+ *     metaStorage: new RedisMetaStorage({ host: 'localhost', port: 6379 })
+ *   })
+ * );
+ * ```
+ */
+export class RedisMetaStorage<T extends File = File> extends MetaStorage<T> {
+  client!: Redis;
+
+  constructor(readonly options: RedisMetaStorageOptions = {}) {
+    const { prefix = 'uploadx:meta:', suffix: _, ...redisOptions } = options;
+    super({ prefix, suffix: '' });
+    if (!RedisCtor) {
+      throw new Error('ioredis is not installed. Install it with: npm install ioredis');
+    }
+    this.client = new RedisCtor(redisOptions);
+    this.client.on('error', (error: Error) => {
+      this.logger.error('Redis connection error', { error });
+    });
+  }
+
+  async save(id: string, file: T): Promise<T> {
+    await this.client.hset(
+      this.key(id),
+      'id',
+      id,
+      'data',
+      JSON.stringify(file),
+      'createdAt',
+      String(file.createdAt ?? '')
+    );
+    return file;
+  }
+
+  async touch(id: string, file: T): Promise<T> {
+    const modifiedAt = new Date().toISOString();
+    await this.client.hset(this.key(id), 'modifiedAt', modifiedAt);
+    return { ...file, modifiedAt } as T;
+  }
+
+  async get(id: string): Promise<T> {
+    const data = await this.client.hget(this.key(id), 'data');
+    if (!data) throw new Error('Meta not found');
+    return JSON.parse(data) as T;
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.client.del(this.key(id));
+  }
+
+  async close(): Promise<void> {
+    await this.client.quit();
+  }
+
+  async list(prefix = ''): Promise<UploadList> {
+    const pattern = `${this.prefix}${prefix}*`;
+    const stream = this.client.scanStream({ match: pattern });
+    const keys = new Set<string>();
+    return new Promise<UploadList>((resolve, reject) => {
+      stream.on('data', (result: string[]) => {
+        for (const key of result) keys.add(key);
+      });
+      stream.on('end', () => {
+        this.fetchItems([...keys])
+          .then(items => {
+            if (items.length !== keys.size) {
+              this.logger.warn('Some metadata entries are missing or corrupted');
+            }
+            resolve({ items });
+          })
+          .catch(reject);
+      });
+      stream.on('error', reject);
+    });
+  }
+
+  toString(): string {
+    return `[${this.constructor.name}: ${JSON.stringify(this.options)}, prefix="${this.prefix}"]`;
+  }
+
+  private key(id: string): string {
+    return `${this.prefix}${id}`;
+  }
+
+  private async fetchItems(keys: string[]): Promise<UploadList['items']> {
+    if (!keys.length) return [];
+    const pipeline = this.client.pipeline();
+    for (const key of keys) pipeline.hmget(key, 'id', 'createdAt', 'modifiedAt');
+    const execResult = (await pipeline.exec()) as [Error | null, (string | null)[]][];
+    if (!execResult) return [];
+    const items: UploadList['items'] = [];
+    for (let i = 0; i < keys.length; i++) {
+      const [error, fields] = execResult[i];
+      if (error || !fields) continue;
+      const [id, createdAt, modifiedAt] = fields;
+      if (!id) continue;
+      items.push({
+        id,
+        createdAt: createdAt ?? '',
+        modifiedAt: modifiedAt ?? createdAt ?? ''
+      });
+    }
+    return items;
+  }
+}

--- a/test/redis-meta-storage.spec.ts
+++ b/test/redis-meta-storage.spec.ts
@@ -1,0 +1,58 @@
+import { RedisMetaStorage } from '../packages/core/src';
+import { metafile } from './shared';
+
+jest.mock('ioredis', () => require('ioredis-mock'));
+
+describe('RedisMetaStorage', () => {
+  let meta: RedisMetaStorage;
+
+  beforeEach(() => {
+    meta = new RedisMetaStorage({ prefix: 'test:' });
+  });
+
+  afterEach(async () => {
+    await meta.close();
+  });
+
+  it('save and get', async () => {
+    const saved = await meta.save(metafile.id, metafile);
+    expect(saved).toBe(metafile);
+    const retrieved = await meta.get(metafile.id);
+    expect(retrieved).toEqual(metafile);
+  });
+
+  it('get throws on missing', async () => {
+    await expect(meta.get('nonexistent')).rejects.toThrow('Meta not found');
+  });
+
+  it('get returns data without modifiedAt', async () => {
+    await meta.save(metafile.id, metafile);
+    await meta.touch(metafile.id, metafile);
+    const retrieved = await meta.get(metafile.id);
+    expect(retrieved).not.toHaveProperty('modifiedAt');
+  });
+
+  it('delete removes key', async () => {
+    await meta.save(metafile.id, metafile);
+    await meta.delete(metafile.id);
+    await expect(meta.get(metafile.id)).rejects.toThrow('Meta not found');
+  });
+
+  it('list returns items with metadata', async () => {
+    const file = { ...metafile, createdAt: '2026-01-01T00:00:00.000Z' };
+    await meta.save(metafile.id, file);
+    const list = await meta.list();
+    expect(list.items).toHaveLength(1);
+    expect(list.items[0]).toMatchObject({
+      id: metafile.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      modifiedAt: '2026-01-01T00:00:00.000Z'
+    });
+  });
+
+  it('list with prefix filters', async () => {
+    await meta.save(metafile.id, metafile);
+    const list = await meta.list('nonexistent');
+    expect(list.items).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Redis-backed metadata storage using Redis hashes. Optional dependency - ioredis.

```ts
import { uploadx, RedisMetaStorage} from '@uploadx/core';
import express from 'express';


const app = express();

const uploads = uploadx({
  uploadDir: 'upload',
  metaStorage: new RedisMetaStorage(),
  maxFileSize: '5GB',
});

app.use('/files', uploads);

app.listen(3002);
```