### PR TITLE
refactor(core): extract createMetaStorage factory function

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ app.use('/files', uploadx({ uploadDir: './uploads', maxFileSize: '10GB' }));
 
 - `uploadDir` DiskStorage upload directory. Default value: `"files"`
 
-- `metaDir` Metadata directory. Overrides `metaStorageConfig.directory`. Defaults to `uploadDir`.
+- `metaDir` Metadata directory. Overrides `metaStorageOptions.directory`. Defaults to `uploadDir`.
 
 - `basePath` Node http base path. Default value: `"/files"`
 
@@ -86,7 +86,7 @@ app.use('/files', uploadx({ uploadDir: './uploads', maxFileSize: '10GB' }));
 
 - `metaStorage` Provide custom meta storage
 
-- `metaStorageConfig` Configure metadata storage
+- `metaStorageOptions` Configure metadata storage
 
 - `maxMetadataSize` Metadata size limit. Default value: `"4MB"`
 

--- a/examples/express-s3.ts
+++ b/examples/express-s3.ts
@@ -13,7 +13,7 @@ const app = express();
 //     accessKeyId: <YOUR_ACCESS_KEY_ID>,
 //     secretAccessKey: <YOUR_SECRET_ACCESS_KEY>
 //   },
-//   metaStorageConfig: { directory: 'upload' }
+//   metaStorageOptions: { directory: 'upload' }
 // });
 
 // The credentials are loaded from a environment

--- a/packages/core/src/storages/create-meta-storage.ts
+++ b/packages/core/src/storages/create-meta-storage.ts
@@ -1,0 +1,39 @@
+import { File } from './file';
+import { LocalMetaStorage } from './local-meta-storage';
+import { MetaStorage } from './meta-storage';
+
+/**
+ * Creates a metadata storage instance based on the provided options.
+ */
+export function createMetaStorage<T extends File = File>(
+  options: {
+    metaStorage?: MetaStorage<T>;
+    metaDir?: string;
+    uploadDir?: string;
+    directory?: string;
+    metaStorageOptions?: unknown;
+    metaStorageConfig?: unknown;
+  },
+  metaStorageConstructor?: new (opts: Record<string, unknown>) => MetaStorage<T>
+): MetaStorage<T> {
+  if (options.metaStorage) return options.metaStorage;
+
+  const metaOpts = options.metaStorageOptions ?? options.metaStorageConfig;
+  const mergedOptions = { ...options, ...(metaOpts as Record<string, unknown>) };
+
+  if (options.metaDir) {
+    return new LocalMetaStorage({ ...mergedOptions, directory: options.metaDir });
+  }
+
+  if ('directory' in mergedOptions) {
+    return new LocalMetaStorage(mergedOptions);
+  }
+
+  if (metaStorageConstructor) {
+    return new metaStorageConstructor(mergedOptions);
+  }
+
+  return new LocalMetaStorage({
+    directory: options.uploadDir ?? options.directory ?? ''
+  });
+}

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -12,6 +12,7 @@ import {
   truncateFile,
   UploadxErrorResponse
 } from '../utils';
+import { createMetaStorage } from './create-meta-storage';
 import {
   File,
   FileInit,
@@ -22,7 +23,7 @@ import {
   partMatch,
   updateSize
 } from './file';
-import { LocalMetaStorage, LocalMetaStorageOptions } from './local-meta-storage';
+import { LocalMetaStorageOptions } from './local-meta-storage';
 import { MetaStorage } from './meta-storage';
 import { BaseStorage, BaseStorageOptions } from './storage';
 
@@ -42,19 +43,23 @@ export type DiskStorageOptions = BaseStorageOptions<DiskFile> & {
   uploadDir?: string;
   /**
    * Metafiles storage directory.
-   * Overrides `metaStorageConfig.directory`.
+   * Overrides `metaStorageOptions.directory`.
    * When not set, defaults to `uploadDir`.
    */
   metaDir?: string;
   /**
-   * Configuring metafile storage on the local disk
+   * Configure metafile storage on the local disk
    * @example
    * ```ts
    * const storage = new DiskStorage({
    *   uploadDir: 'upload',
-   *   metaStorageConfig: { uploadDir: '/tmp/upload-metafiles', prefix: '.' }
+   *   metaStorageOptions: { directory: '/tmp/upload-metafiles', prefix: '.' }
    * });
    * ```
+   */
+  metaStorageOptions?: LocalMetaStorageOptions;
+  /**
+   * @deprecated Use {@link metaStorageOptions} instead
    */
   metaStorageConfig?: LocalMetaStorageOptions;
 };
@@ -70,13 +75,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
   constructor(public options: DiskStorageOptions = {}) {
     super(options);
     this.directory = options.uploadDir ?? (options.directory || this.basePath.replace(/^\//, ''));
-    if (options.metaStorage) {
-      this.meta = options.metaStorage;
-    } else {
-      const metaConfig = { ...options, ...options.metaStorageConfig };
-      metaConfig.directory = options.metaDir ?? metaConfig.directory ?? this.directory;
-      this.meta = new LocalMetaStorage(metaConfig);
-    }
+    this.meta = createMetaStorage({ ...options, uploadDir: this.directory });
     this.isReady = false;
     this.accessCheck()
       .then(() => (this.isReady = true))

--- a/packages/core/src/storages/index.ts
+++ b/packages/core/src/storages/index.ts
@@ -1,3 +1,4 @@
+export * from './create-meta-storage';
 export * from './disk-storage';
 export * from './file';
 export * from './storage';

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -1,6 +1,7 @@
 import {
   BaseStorage,
   BaseStorageOptions,
+  createMetaStorage,
   ERRORS,
   fail,
   File,
@@ -11,7 +12,6 @@ import {
   getHeader,
   hasContent,
   IncomingMessage,
-  LocalMetaStorage,
   LocalMetaStorageOptions,
   mapValues,
   MetaStorage,
@@ -55,23 +55,30 @@ export interface GCStorageOptions extends BaseStorageOptions<GCSFile>, GoogleAut
    */
   clientDirectUpload?: boolean;
   /**
+   * Metafiles storage directory.
+   * When set, metafiles are stored locally instead of in GCS.
+   */
+  metaDir?: string;
+  /**
    * Configure metafiles storage
    * @example
    * ```ts
    * Using local metafiles
    * const storage = new GCStorage({
    *   bucket: 'uploads',
-   *   metaStorageConfig: { directory: '/tmp/upload-metafiles' }
+   *   metaStorageOptions: { directory: '/tmp/upload-metafiles' }
    * })
    * ```
    * Using a separate bucket for metafiles
    * ```ts
    * const storage = new GCStorage({
    *   bucket: 'uploads',
-   *   metaStorageConfig: { bucket: 'upload-metafiles' }
+   *   metaStorageOptions: { bucket: 'upload-metafiles' }
    * })
    * ```
    */
+  metaStorageOptions?: LocalMetaStorageOptions | GCSMetaStorageOptions;
+  /** @deprecated Use {@link metaStorageOptions} instead */
   metaStorageConfig?: LocalMetaStorageOptions | GCSMetaStorageOptions;
 }
 
@@ -104,15 +111,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
 
   constructor(public options: GCStorageOptions = {}) {
     super(options);
-    if (options.metaStorage) {
-      this.meta = options.metaStorage;
-    } else {
-      const metaConfig = { ...options, ...options.metaStorageConfig };
-      this.meta =
-        'directory' in metaConfig
-          ? new LocalMetaStorage(metaConfig)
-          : new GCSMetaStorage(metaConfig);
-    }
+    this.meta = createMetaStorage(options, GCSMetaStorage);
 
     this.bucket = options.bucket || GCSConfig.bucketName;
     this.storageBaseURI = [GCSConfig.storageAPI, this.bucket, 'o'].join('/');

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -18,6 +18,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
   BaseStorage,
   BaseStorageOptions,
+  createMetaStorage,
   ERRORS,
   fail,
   File,
@@ -27,7 +28,6 @@ import {
   getFileStatus,
   hasContent,
   IncomingMessage,
-  LocalMetaStorage,
   LocalMetaStorageOptions,
   mapValues,
   MetaStorage,
@@ -75,6 +75,11 @@ export type S3StorageOptions = BaseStorageOptions<S3File> &
      */
     partSize?: number | string;
     /**
+     * Metafiles storage directory.
+     * When set, metafiles are stored locally instead of in S3.
+     */
+    metaDir?: string;
+    /**
      * Configure metafiles storage
      * @example
      * Using local metafiles
@@ -82,7 +87,7 @@ export type S3StorageOptions = BaseStorageOptions<S3File> &
      * const storage = new S3Storage({
      *   bucket: 'uploads',
      *   region: 'eu-west-3',
-     *   metaStorageConfig: { directory: '/tmp/upload-metafiles' }
+     *   metaStorageOptions: { directory: '/tmp/upload-metafiles' }
      * })
      * ```
      * Using a separate bucket for metafiles
@@ -90,10 +95,12 @@ export type S3StorageOptions = BaseStorageOptions<S3File> &
      * const storage = new S3Storage({
      *   bucket: 'uploads',
      *   region: 'eu-west-3',
-     *   metaStorageConfig: { bucket: 'upload-metafiles' }
+     *   metaStorageOptions: { bucket: 'upload-metafiles' }
      * })
      * ```
      */
+    metaStorageOptions?: LocalMetaStorageOptions | S3MetaStorageOptions;
+    /** @deprecated Use {@link metaStorageOptions} instead */
     metaStorageConfig?: LocalMetaStorageOptions | S3MetaStorageOptions;
     /**
      * @deprecated Use standard auth providers
@@ -113,7 +120,7 @@ export type S3StorageOptions = BaseStorageOptions<S3File> &
  *    accessKeyId: <YOUR_ACCESS_KEY_ID>,
  *    secretAccessKey: <YOUR_SECRET_ACCESS_KEY>
  *  },
- *  metaStorageConfig: { directory: '/tmp/upload-metafiles' }
+ *  metaStorageOptions: { directory: '/tmp/upload-metafiles' }
  * });
  * ```
  */
@@ -139,15 +146,7 @@ export class S3Storage extends BaseStorage<S3File> {
     }
     const clientConfig = { ...options };
     this.client = new S3Client(clientConfig);
-    if (options.metaStorage) {
-      this.meta = options.metaStorage;
-    } else {
-      const metaConfig = { ...options, ...options.metaStorageConfig };
-      this.meta =
-        'directory' in metaConfig
-          ? new LocalMetaStorage(metaConfig)
-          : new S3MetaStorage(metaConfig);
-    }
+    this.meta = createMetaStorage(options, S3MetaStorage);
     this.isReady = false;
     this.accessCheck()
       .then(() => (this.isReady = true))

--- a/test/create-meta-storage.spec.ts
+++ b/test/create-meta-storage.spec.ts
@@ -1,0 +1,75 @@
+import {
+  createMetaStorage,
+  File,
+  LocalMetaStorage,
+  MetaStorage,
+  MetaStorageOptions
+} from '../packages/core/src';
+
+class TestMetaStorage extends MetaStorage<File> {
+  constructor(opts: Record<string, unknown>) {
+    super(opts as MetaStorageOptions);
+  }
+}
+
+describe('createMetaStorage', () => {
+  it('returns metaStorage as-is', () => {
+    const meta = new MetaStorage<File>();
+    expect(createMetaStorage({ metaStorage: meta })).toBe(meta);
+  });
+
+  it('creates LocalMetaStorage with metaDir', () => {
+    const meta = createMetaStorage({ metaDir: '/custom/path' });
+    expect(meta).toBeInstanceOf(LocalMetaStorage);
+    expect((meta as LocalMetaStorage).directory).toBe('/custom/path');
+  });
+
+  it('creates LocalMetaStorage with metaStorageOptions.directory', () => {
+    const meta = createMetaStorage({ metaStorageOptions: { directory: '/opt/path' } });
+    expect(meta).toBeInstanceOf(LocalMetaStorage);
+    expect((meta as LocalMetaStorage).directory).toBe('/opt/path');
+  });
+
+  it('creates LocalMetaStorage with deprecated metaStorageConfig.directory', () => {
+    const meta = createMetaStorage({ metaStorageConfig: { directory: '/old/path' } });
+    expect(meta).toBeInstanceOf(LocalMetaStorage);
+    expect((meta as LocalMetaStorage).directory).toBe('/old/path');
+  });
+
+  it('metaDir overrides metaStorageOptions.directory', () => {
+    const meta = createMetaStorage({
+      metaDir: '/override',
+      metaStorageOptions: { directory: '/ignored' }
+    });
+    expect((meta as LocalMetaStorage).directory).toBe('/override');
+  });
+
+  it('metaDir overrides metaStorageConfig.directory', () => {
+    const meta = createMetaStorage({
+      metaDir: '/override',
+      metaStorageConfig: { directory: '/ignored' }
+    });
+    expect((meta as LocalMetaStorage).directory).toBe('/override');
+  });
+
+  it('uses metaStorageConstructor when no local indicators', () => {
+    const meta = createMetaStorage({}, TestMetaStorage);
+    expect(meta).toBeInstanceOf(TestMetaStorage);
+  });
+
+  it('falls back to LocalMetaStorage when no constructor', () => {
+    const meta = createMetaStorage({});
+    expect(meta).toBeInstanceOf(LocalMetaStorage);
+  });
+
+  it('falls back to uploadDir for LocalMetaStorage directory', () => {
+    const meta = createMetaStorage({ uploadDir: '/uploads' });
+    expect(meta).toBeInstanceOf(LocalMetaStorage);
+    expect((meta as LocalMetaStorage).directory).toBe('/uploads');
+  });
+
+  it('uses deprecated directory when uploadDir also set', () => {
+    const meta = createMetaStorage({ uploadDir: '/new', directory: '/old' });
+    expect((meta as LocalMetaStorage).directory).toBe('/old');
+  });
+});


### PR DESCRIPTION
- Extracted duplicate meta storage logic into shared `createMetaStorage()`
- Added `metaDir` option to S3 and GCS for local metadata storage
- Renamed `metaStorageConfig` -> `metaStorageOptions` (old kept as deprecated)