### PR TITLE
feat(core): expiration shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,15 +154,16 @@ import { fromEnv, uploadx } from '@uploadx/core';
 app.use('/files', uploadx({ ...fromEnv() }));
 ```
 
-| Variable             | Option             | Description                   |
-| -------------------- | ------------------ | ----------------------------- |
-| `BASE_URL`           | `baseUrl`          | Base URL for upload links     |
-| `MAX_FILE_SIZE`      | `maxFileSize`      | File size limit (e.g. `10GB`) |
-| `ALLOWED_MIME_TYPES` | `allowedMimeTypes` | Comma-separated MIME types    |
-| `BASE_PATH`          | `basePath`         | HTTP base path                |
-| `UPLOAD_DIR`         | `uploadDir`        | Upload directory              |
-| `META_DIR`           | `metaDir`          | Metafiles directory           |
-| `LOG_LEVEL`          | `logLevel`         | Built-in console logger level |
+| Variable             | Option             | Description                                |
+| -------------------- | ------------------ | ------------------------------------------ |
+| `ALLOWED_MIME_TYPES` | `allowedMimeTypes` | Comma-separated MIME types                 |
+| `BASE_PATH`          | `basePath`         | HTTP base path                             |
+| `BASE_URL`           | `baseUrl`          | Base URL for upload links                  |
+| `EXPIRATION`         | `expiration`       | Upload expiration age (e.g. `6h`, `30min`) |
+| `LOG_LEVEL`          | `logLevel`         | Built-in console logger level              |
+| `MAX_FILE_SIZE`      | `maxFileSize`      | File size limit (e.g. `10GB`)              |
+| `META_DIR`           | `metaDir`          | Metafiles directory                        |
+| `UPLOAD_DIR`         | `uploadDir`        | Upload directory                           |
 
 > **Note:** `UPLOADX_SECRET` is read directly from `process.env` and is **not** included in `fromEnv()`.
 

--- a/examples/express-basic.ts
+++ b/examples/express-basic.ts
@@ -10,7 +10,7 @@ const uploads = uploadx({
   maxFileSize: '5GB',
   allowedMimeTypes: ['video/*', 'image/*'],
   namingFunction: file => file.originalName,
-  expiration: { maxAge: '1h', purgeInterval: '10min' },
+  expiration: '1h',
   onComplete: file => {
     console.log('File upload complete: ', file.originalName);
     return file;

--- a/examples/express-logtape.ts
+++ b/examples/express-logtape.ts
@@ -31,7 +31,7 @@ async function startApp() {
     allowedMimeTypes: ['video/*', 'image/*'],
     useRelativeLocation: true,
     namingFunction: file => file.originalName,
-    expiration: { maxAge: '1h', purgeInterval: '10min' }
+    expiration: '1h'
   });
 
   app.use('/files', uploads);

--- a/examples/express-polling.ts
+++ b/examples/express-polling.ts
@@ -13,7 +13,7 @@ mkdir(destinationDir, { recursive: true }).catch(console.error);
 
 const storage = new DiskStorage({
   uploadDir: uploadDir,
-  expiration: { maxAge: '1h', purgeInterval: '10min' }
+  expiration: { maxAge: '1h', purgeInterval: '10min', rolling: true }
 });
 const upload = new Uploadx({ storage }).upload;
 

--- a/examples/express-redis.ts
+++ b/examples/express-redis.ts
@@ -10,7 +10,7 @@ const uploads = uploadx({
   metaStorage: new RedisMetaStorage(),
   maxFileSize: '5GB',
   allowedMimeTypes: ['video/*', 'image/*'],
-  expiration: { maxAge: '30min', purgeInterval: '3min' },
+  expiration: { maxAge: '30min', purgeInterval: '5min', rolling: true },
   onComplete: file => {
     console.log('File upload complete: ', file.originalName);
     return file;

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -21,7 +21,7 @@ app.use(
   uploadx.upload({
     maxFileSize: '5GB',
     uploadDir: './upload',
-    expiration: { maxAge: '1h', purgeInterval: '10min' },
+    expiration: '1h',
     userIdentifier: (req: AuthRequest) => (req.user ? `${req.user.id}-${req.user.email}` : ''),
     onComplete: file => {
       appLogger.info(`File upload complete: ${file.name}`);

--- a/examples/s3-direct.ts
+++ b/examples/s3-direct.ts
@@ -15,7 +15,7 @@ const storage = new S3Storage({
   forcePathStyle: true,
   clientDirectUpload: true, // send presigned urls to the client for upload directly to S3 storage
   partSize: '8MB', // optionally override part size
-  expiration: { maxAge: '1h', purgeInterval: '15min' },
+  expiration: '1h',
   logLevel: 'error',
   logger: logger
 });

--- a/examples/validation.ts
+++ b/examples/validation.ts
@@ -19,7 +19,7 @@ const onComplete: OnComplete = file => {
 const storage = new DiskStorage({
   uploadDir: process.env.UPLOAD_DIR || 'upload',
   onComplete,
-  expiration: { maxAge: '1h', purgeInterval: '10min' },
+  expiration: '1h',
   validation: {
     mime: { value: ['video/*'], response: [415, { message: 'video only' }] },
     size2: {

--- a/packages/core/src/storages/config.ts
+++ b/packages/core/src/storages/config.ts
@@ -1,4 +1,4 @@
-import { UploadxErrorResponse } from '../utils';
+import { normalizeExpiration } from './expiration';
 import { File } from './file';
 import { BaseStorageOptions } from './storage';
 
@@ -12,7 +12,7 @@ export class ConfigHandler<T extends File = File> {
     onUpdate: (file: File) => file,
     onCreate: () => '',
     onDelete: () => '',
-    onError: (response: UploadxErrorResponse) => response,
+    onError: response => response,
     basePath: '/files',
     validation: {},
     maxMetadataSize: '4MB'
@@ -38,6 +38,8 @@ export class ConfigHandler<T extends File = File> {
       }
     }
     this._config = { ...this._config, ...normalized };
+    const expiration = normalizeExpiration(this._config.expiration);
+    this._config.expiration = expiration;
     return this._config as Required<BaseStorageOptions<T>>;
   }
 

--- a/packages/core/src/storages/expiration.ts
+++ b/packages/core/src/storages/expiration.ts
@@ -1,0 +1,51 @@
+import { clamp, toMilliseconds } from '../utils';
+
+/**
+ * Age of the upload, after which it is considered expired and can be deleted
+ */
+export interface ExpirationOptions {
+  maxAge: number | string;
+  purgeInterval?: number | string;
+  rolling?: boolean;
+}
+
+/** Shorthand type for expiration — a string/number is treated as `maxAge` */
+export type ExpirationInput = string | number | ExpirationOptions;
+
+/**
+ * Computes a reasonable `purgeInterval` from `maxAge`.
+ *
+ * Formula: `clamp(maxAge / 12, 5min, 1h)`
+ *
+ * @example
+ * ```ts
+ * computePurgeInterval('1h')  // 300000 (5min)
+ * computePurgeInterval('6h')  // 1800000 (30min)
+ * computePurgeInterval('1d')  // 3600000 (1h)
+ * computePurgeInterval('7d')  // 3600000 (1h)
+ * ```
+ */
+export function computePurgeInterval(maxAge: string | number): number | undefined {
+  const maxAgeMs = toMilliseconds(maxAge);
+  if (!maxAgeMs) return undefined;
+  const MIN_PURGE_MS = 5 * 60 * 1000;
+  const MAX_PURGE_MS = 60 * 60 * 1000;
+  return clamp(maxAgeMs / 12, MIN_PURGE_MS, MAX_PURGE_MS);
+}
+
+/**
+ * Normalizes `ExpirationInput` to `ExpirationOptions`.
+ *
+ * - `string | number` → `{ maxAge, purgeInterval: auto }`
+ * - `ExpirationOptions` → returned as-is
+ * - `null | undefined` → `undefined`
+ */
+export function normalizeExpiration(expiration?: ExpirationInput): ExpirationOptions | undefined {
+  if (!expiration) return undefined;
+  if (typeof expiration === 'string' || typeof expiration === 'number') {
+    return { maxAge: expiration, purgeInterval: computePurgeInterval(expiration), rolling: true };
+  }
+  // Validate object maxAge early (throws on invalid).
+  toMilliseconds(expiration.maxAge);
+  return { ...expiration };
+}

--- a/packages/core/src/storages/index.ts
+++ b/packages/core/src/storages/index.ts
@@ -6,3 +6,4 @@ export * from './local-meta-storage';
 export * from './meta-storage';
 export * from './redis-meta-storage';
 export * from './config';
+export * from './expiration';

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -3,6 +3,7 @@ import { setInterval } from 'timers';
 import { IncomingMessage, UploadxResponse } from '../types';
 import {
   Cache,
+  clamp,
   configureSimpleLogger,
   ErrorMap,
   ErrorResponses,
@@ -16,12 +17,12 @@ import {
   typeis,
   UploadxErrorResponse,
   uploadxLogger,
-  validateTimerInterval,
   Validation,
   Validator,
   ValidatorConfig
 } from '../utils';
 import { ConfigHandler } from './config';
+import { ExpirationInput, ExpirationOptions } from './expiration';
 import { File, FileInit, FileName, FilePart, FileQuery, isExpired, updateMetadata } from './file';
 import { MetaStorage, UploadList } from './meta-storage';
 
@@ -41,21 +42,6 @@ export type OnDelete<T extends File = File> = (file: T) => unknown;
 export type OnError = (error: UploadxErrorResponse) => UploadxResponse;
 
 export type PurgeList = UploadList & { maxAgeMs: number };
-
-export interface ExpirationOptions {
-  /**
-   * Age of the upload, after which it is considered expired and can be deleted
-   */
-  maxAge: number | string;
-  /**
-   * Auto purging interval for expired uploads
-   */
-  purgeInterval?: number | string;
-  /**
-   * Auto prolong expiring uploads
-   */
-  rolling?: boolean;
-}
 
 export interface BaseStorageOptions<T extends File> {
   /**
@@ -114,17 +100,16 @@ export interface BaseStorageOptions<T extends File> {
    *
    * @example
    * ```ts
-   * app.use(
-   *   '/upload',
-   *   uploadx.upload({
-   *     uploadDir: 'upload',
-   *     expiration: { maxAge: '6h', purgeInterval: '30min' },
-   *     onComplete
-   *   })
-   * );
+   * // Shorthand — `purgeInterval` is computed automatically
+   * { expiration: '6h' }
+   * ```
+   * @example
+   * ```ts
+   * // Full control
+   * { expiration: { maxAge: '6h', purgeInterval: '30min', rolling: true } }
    * ```
    */
-  expiration?: ExpirationOptions;
+  expiration?: ExpirationInput;
   /**
    * Set built-in logger severity level
    * @defaultValue 'none'
@@ -149,7 +134,9 @@ export abstract class BaseStorage<TFile extends File> {
   protected namingFunction: (file: TFile, req: any) => string;
   private _errorResponses: ErrorResponses = {};
   abstract meta: MetaStorage<TFile>;
-  public config: Required<BaseStorageOptions<TFile>>;
+  readonly config: Required<BaseStorageOptions<TFile>> & {
+    expiration: ExpirationOptions | undefined;
+  };
 
   protected constructor(public options: BaseStorageOptions<TFile>) {
     // Configure the logger if a logLevel is specified
@@ -157,7 +144,7 @@ export abstract class BaseStorage<TFile extends File> {
       configureSimpleLogger(options.logLevel);
     }
     const configHandler = new ConfigHandler<TFile>();
-    this.config = configHandler.set(options);
+    this.config = configHandler.set(options) as typeof this.config;
     this.basePath = this.config.basePath;
     this.onCreate = normalizeHookResponse(this.config.onCreate);
     this.onUpdate = normalizeHookResponse(this.config.onUpdate);
@@ -335,10 +322,18 @@ export abstract class BaseStorage<TFile extends File> {
   }
 
   protected startAutoPurge(purgeInterval: number): void {
-    validateTimerInterval(purgeInterval, 'purgeInterval');
+    const MAX_TIMER_INTERVAL = 2_147_483_647;
+    const MIN_PURGE_INTERVAL = 60_000;
+    const interval = clamp(purgeInterval, MIN_PURGE_INTERVAL, MAX_TIMER_INTERVAL);
+    if (interval !== purgeInterval) {
+      this.logger.warn('purgeInterval clamped from {value} to {clamped}', {
+        value: purgeInterval,
+        clamped: interval
+      });
+    }
     setInterval(
       () => void this.purge().catch(e => this.logger.error('purge error: {e}', { e })),
-      purgeInterval
+      interval
     ).unref();
   }
 

--- a/packages/core/src/utils/core-env.ts
+++ b/packages/core/src/utils/core-env.ts
@@ -7,7 +7,8 @@ const CORE_ENV = {
   BASE_PATH: 'BASE_PATH',
   UPLOAD_DIR: 'UPLOAD_DIR',
   META_DIR: 'META_DIR',
-  LOG_LEVEL: 'LOG_LEVEL'
+  LOG_LEVEL: 'LOG_LEVEL',
+  EXPIRATION: 'EXPIRATION'
 } as const;
 
 type EnvKey = keyof typeof CORE_ENV;
@@ -27,12 +28,14 @@ export const commonFromEnv = (prefix = DEFAULT_PREFIX): Partial<DiskStorageOptio
     .map(mime => mime.trim())
     .filter(Boolean);
   const logLevel = getEnv(prefix, 'LOG_LEVEL') as DiskStorageOptions['logLevel'];
+  const expiration = getEnv(prefix, 'EXPIRATION');
   return {
     ...(baseUrl && { baseUrl }),
     ...(maxFileSize && { maxFileSize }),
     ...(basePath && { basePath }),
     ...(allowedMimeTypes?.length && { allowedMimeTypes }),
-    ...(logLevel && { logLevel })
+    ...(logLevel && { logLevel }),
+    ...(expiration && { expiration })
   };
 };
 

--- a/packages/core/src/utils/primitives.ts
+++ b/packages/core/src/utils/primitives.ts
@@ -110,15 +110,6 @@ export function toMilliseconds(value?: string | number): number | undefined {
   return durationToMs(value);
 }
 
-export function validateTimerInterval(value: number, name: string): void {
-  const INT32_MAX = 2147483647;
-  if (value >= INT32_MAX) {
-    throw Error(
-      `"${name}" must be less than ${INT32_MAX} ms (${(INT32_MAX / 86400000).toFixed(2)} days)`
-    );
-  }
-}
-
 /**
  * Convert a human-readable duration to seconds
  */
@@ -126,6 +117,13 @@ export function toSeconds(value?: string | number): number | undefined {
   if (isNumber(value)) return Math.floor(value / 1000);
   if (!value) return undefined;
   return Math.floor(durationToMs(value) / 1000);
+}
+
+/**
+ * Clamps a value between a minimum and maximum bound
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(value, max));
 }
 
 /**

--- a/test/expiration.spec.ts
+++ b/test/expiration.spec.ts
@@ -1,0 +1,70 @@
+import { TestStorage } from './shared';
+
+describe('expiration shorthand', () => {
+  it('should normalize string shorthand to ExpirationOptions', () => {
+    const s = new TestStorage({ expiration: '6h' });
+    expect(s.config.expiration).toBeDefined();
+    expect(s.config.expiration?.maxAge).toBe('6h');
+    expect(s.config.expiration?.purgeInterval).toBe(1800000); // 30min (6h/12)
+  });
+
+  it('should normalize number shorthand to ExpirationOptions', () => {
+    const s = new TestStorage({ expiration: 3600000 });
+    expect(s.config.expiration).toBeDefined();
+    expect(s.config.expiration?.maxAge).toBe(3600000);
+    expect(s.config.expiration?.purgeInterval).toBe(300000); // 5min (1h/12 clamped)
+  });
+
+  it('should keep ExpirationOptions object as-is', () => {
+    const s = new TestStorage({ expiration: { maxAge: '1h', rolling: true } });
+    expect(s.config.expiration).toBeDefined();
+    expect(s.config.expiration?.maxAge).toBe('1h');
+    expect(s.config.expiration?.rolling).toBe(true);
+    // purgeInterval should NOT be added for object syntax without it
+    expect(s.config.expiration?.purgeInterval).toBeUndefined();
+  });
+
+  it('should preserve explicit purgeInterval in object syntax', () => {
+    const s = new TestStorage({ expiration: { maxAge: '1h', purgeInterval: '15min' } });
+    expect(s.config.expiration).toBeDefined();
+    expect(s.config.expiration?.maxAge).toBe('1h');
+    // purgeInterval can be string or number - it will be converted to ms when used
+    expect(s.config.expiration?.purgeInterval).toBe('15min');
+  });
+
+  it('should preserve explicit numeric purgeInterval', () => {
+    const s = new TestStorage({ expiration: { maxAge: '6h', purgeInterval: 600000 } });
+    expect(s.config.expiration).toBeDefined();
+    expect(s.config.expiration?.maxAge).toBe('6h');
+    expect(s.config.expiration?.purgeInterval).toBe(600000); // explicit 10min
+  });
+
+  it('should compute purgeInterval for 7d as 1h', () => {
+    const s = new TestStorage({ expiration: '7d' });
+    expect(s.config.expiration?.purgeInterval).toBe(3600000); // 1h
+  });
+
+  it('should compute purgeInterval for 10min as 5min (clamp)', () => {
+    const s = new TestStorage({ expiration: '10min' });
+    expect(s.config.expiration?.purgeInterval).toBe(300000); // 5min
+  });
+
+  it('should be undefined when expiration is not set', () => {
+    const s = new TestStorage();
+    expect(s.config.expiration).toBeUndefined();
+  });
+
+  it('should throw when shorthand maxAge is invalid', () => {
+    expect(() => new TestStorage({ expiration: 'abc' })).toThrow('Invalid duration format');
+  });
+
+  it('should throw when purgeInterval is invalid', () => {
+    expect(
+      () => new TestStorage({ expiration: { maxAge: '1h', purgeInterval: 'abc' } })
+    ).toThrow('Invalid duration format');
+  });
+
+  it('should throw when object maxAge is invalid', () => {
+    expect(() => new TestStorage({ expiration: { maxAge: 'abc' } })).toThrow('Invalid duration format');
+  });
+});


### PR DESCRIPTION
- Shorthand `expiration` (`'6h'`, `7200000`):  
  - Auto-sets `maxAge`, `purgeInterval = maxAge/12` (clamped: 5 min–1 h), `rolling: true`  
- Backward compatible: full config object still supported  
- New env var: `EXPIRATION`  
- Usage example:
  ```ts
  app.use('/uploads', uploadx({ expiration: '6h', /* ... */ }));