### PR TITLE
refactor(storage): prevent overlapping purge cycles

### DIFF
--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -343,6 +343,14 @@ export abstract class BaseStorage<TFile extends File> {
     this.purgeTimeoutId = setTimeout(runPurge, interval).unref();
   }
 
+
+  protected stopAutoPurge(): void {
+    if (this.purgeTimeoutId) {
+      clearTimeout(this.purgeTimeoutId);
+      this.purgeTimeoutId = undefined;
+    }
+  }
+
   protected updateTimestamps(file: TFile): TFile {
     file.createdAt ??= new Date().toISOString();
     const maxAgeMs = toMilliseconds(this.config.expiration?.maxAge);

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -1,5 +1,4 @@
 import bytes from 'bytes';
-import { setInterval } from 'timers';
 import { IncomingMessage, UploadxResponse } from '../types';
 import {
   Cache,
@@ -137,6 +136,7 @@ export abstract class BaseStorage<TFile extends File> {
   readonly config: Required<BaseStorageOptions<TFile>> & {
     expiration: ExpirationOptions | undefined;
   };
+  private purgeTimeoutId?: NodeJS.Timeout;
 
   protected constructor(public options: BaseStorageOptions<TFile>) {
     // Configure the logger if a logLevel is specified
@@ -331,10 +331,16 @@ export abstract class BaseStorage<TFile extends File> {
         clamped: interval
       });
     }
-    setInterval(
-      () => void this.purge().catch(e => this.logger.error('purge error: {e}', { e })),
-      interval
-    ).unref();
+    const runPurge = (): void => {
+      this.purge()
+        .catch(e => this.logger.error('purge error: {e}', { e }))
+        .finally(() => {
+          if (this.purgeTimeoutId) {
+            this.purgeTimeoutId = setTimeout(runPurge, interval).unref();
+          }
+        });
+    };
+    this.purgeTimeoutId = setTimeout(runPurge, interval).unref();
   }
 
   protected updateTimestamps(file: TFile): TFile {

--- a/test/expiration.spec.ts
+++ b/test/expiration.spec.ts
@@ -59,12 +59,14 @@ describe('expiration shorthand', () => {
   });
 
   it('should throw when purgeInterval is invalid', () => {
-    expect(
-      () => new TestStorage({ expiration: { maxAge: '1h', purgeInterval: 'abc' } })
-    ).toThrow('Invalid duration format');
+    expect(() => new TestStorage({ expiration: { maxAge: '1h', purgeInterval: 'abc' } })).toThrow(
+      'Invalid duration format'
+    );
   });
 
   it('should throw when object maxAge is invalid', () => {
-    expect(() => new TestStorage({ expiration: { maxAge: 'abc' } })).toThrow('Invalid duration format');
+    expect(() => new TestStorage({ expiration: { maxAge: 'abc' } })).toThrow(
+      'Invalid duration format'
+    );
   });
 });

--- a/test/storage.spec.ts
+++ b/test/storage.spec.ts
@@ -108,3 +108,22 @@ describe('BaseStorage', () => {
     expect(JSON.stringify(normalized)).not.toContain('secret-location');
   });
 });
+
+describe('autoPurge', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('stopAutoPurge stops the purge cycle', async () => {
+    jest.useFakeTimers();
+    const storage = new TestStorage({ expiration: '1h' });
+    const purgeSpy = jest.spyOn(storage, 'purge');
+    const purgeInterval = storage.config.expiration.purgeInterval as number;
+    await jest.advanceTimersByTimeAsync(purgeInterval);
+    expect(purgeSpy).toHaveBeenCalledTimes(1);
+    // @ts-expect-error - accessing protected method
+    storage.stopAutoPurge();
+    await jest.advanceTimersByTimeAsync(purgeInterval);
+    expect(purgeSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
- Replaces `setInterval` with recursive `setTimeout` in `startAutoPurge` to prevent overlapping purge cycles.
- Adds `stopAutoPurge()` method for stopping the purge timer.
