### PR TITLE
refactor(core): replace url.parse() with native URL API

### DIFF
--- a/examples/express-gcs.ts
+++ b/examples/express-gcs.ts
@@ -5,6 +5,7 @@ const PORT = process.env.PORT || 3002;
 
 const app = express();
 
+// Credentials: set GOOGLE_APPLICATION_CREDENTIALS or pass keyFile option
 const storage = new GCStorage({
   bucket: 'my-bucket',
   maxFileSize: '5GB',

--- a/examples/gcs-direct.ts
+++ b/examples/gcs-direct.ts
@@ -1,7 +1,6 @@
 import { cors, MetaStorage, Uploadx } from '@uploadx/core';
-import { GCStorage } from '@uploadx/gcs';
+import { fromEnv, GCStorage } from '@uploadx/gcs';
 import { createServer } from 'http';
-import { parse } from 'url';
 
 const PORT = process.env.PORT || 3002;
 
@@ -13,7 +12,8 @@ const storage = new GCStorage({
   maxFileSize: '5GB',
   allowedMimeTypes: ['video/*', 'image/*'],
   namingFunction: file => file.originalName,
-  metaStorage: new MetaStorage()
+  metaStorage: new MetaStorage(),
+  ...fromEnv()
 });
 
 const uploadx = new Uploadx({ storage });
@@ -22,7 +22,7 @@ uploadx.on('created', file =>
 );
 
 createServer((req, res) => {
-  const { pathname } = parse(req.url || '');
+  const { pathname } = new URL(req.url || '', 'http://localhost');
   if (pathname === '/files') {
     uploadx.handle(req, res);
   } else {

--- a/examples/node-http-server.js
+++ b/examples/node-http-server.js
@@ -1,5 +1,4 @@
 const { createServer } = require('http');
-const { parse } = require('url');
 const { DiskStorage, Uploadx, cors } = require('@uploadx/core');
 
 const PORT = process.env.PORT || 3002;
@@ -23,7 +22,7 @@ uploadx.on('completed', file => console.log('completed: ', file));
 uploadx.on('updated', file => console.log(' metadata updated: ', file));
 
 const server = createServer((req, res) => {
-  const { pathname } = parse(req.url || '');
+  const { pathname } = new URL(req.url || '', 'http://localhost');
   if (pathname === '/files') {
     uploadx.upload(req, res, () => {
       uploadx.send(res, { body: req.body, statusCode: 200 });

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,7 +1,6 @@
 // @ts-check
 const { cors, DiskStorage, Multipart, Tus, Uploadx, fromEnv } = require('@uploadx/core');
 const { createServer } = require('http');
-const url = require('url');
 
 const PORT = process.env.PORT || 3002;
 const path = '/files';
@@ -23,7 +22,7 @@ const tus = new Tus({ storage });
 const multipart = new Multipart({ storage });
 
 createServer((req, res) => {
-  const { pathname, query = { uploadType: '' } } = url.parse(req.url ?? '', true);
+  const { pathname, searchParams } = new URL(req.url ?? '', 'http://localhost');
   if (pathname === '/healthcheck') {
     const healthcheck = {
       memoryUsage: process.memoryUsage(),
@@ -33,7 +32,7 @@ createServer((req, res) => {
     };
     corsHandler(req, res, () => uploadx.send(res, { body: healthcheck }));
   } else if (pathname && pathRegexp.test(pathname)) {
-    switch (query.uploadType) {
+    switch (searchParams.get('uploadType')) {
       case 'multipart':
         multipart.handle(req, res);
         break;

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-import url from 'url';
 import {
   BaseStorage,
   DiskStorage,
@@ -224,7 +223,7 @@ export abstract class BaseHandler<TFile extends UploadxFile>
    * Get id from request
    */
   getId(req: IncomingMessage): string {
-    const pathname = url.parse(req.url as string).pathname || '';
+    const { pathname } = new URL(req.url || '', 'http://localhost');
     const path = req.originalUrl
       ? `/${pathname}`.replace('//', '')
       : `/${pathname}`.replace(`/${this.storage.basePath}/`, '');
@@ -242,8 +241,8 @@ export abstract class BaseHandler<TFile extends UploadxFile>
    * Build file url from request
    */
   buildFileUrl(req: IncomingMessage, file: TFile): string {
-    const { query, pathname = '' } = url.parse(req.originalUrl || (req.url as string), true);
-    const relative = url.format({ pathname: `${pathname as string}/${file.id}`, query });
+    const requestUrl = new URL(req.originalUrl || req.url || '', 'http://localhost');
+    const relative = `${requestUrl.pathname}/${file.id}${requestUrl.search}`;
     if (this.storage.config.useRelativeLocation) return relative;
     const { baseUrl } = this.storage.config;
     const base = typeof baseUrl === 'function' ? baseUrl(req) : baseUrl || getBaseUrl(req);

--- a/packages/core/src/handlers/uploadx.ts
+++ b/packages/core/src/handlers/uploadx.ts
@@ -1,4 +1,3 @@
-import url from 'url';
 import { Checksum, FileInit, UploadxFile } from '../storages';
 import { Headers, IncomingMessage, ServerResponse } from '../types';
 import { ERRORS, fail, getBaseUrl, getHeader, getJsonBody, setHeaders } from '../utils';
@@ -87,8 +86,8 @@ export class Uploadx<TFile extends UploadxFile> extends BaseHandler<TFile> {
   }
 
   getId(req: IncomingMessage): string {
-    const { query } = url.parse(req.url || '', true);
-    return (query.upload_id || query.prefix || super.getId(req)) as string;
+    const params = new URL(req.url || '', 'http://localhost').searchParams;
+    return (params.get('upload_id') || params.get('prefix') || super.getId(req));
   }
 
   buildHeaders(file: UploadxFile, headers: Headers = {}): Headers {
@@ -105,9 +104,9 @@ export class Uploadx<TFile extends UploadxFile> extends BaseHandler<TFile> {
   ): string {
     if (file.GCSUploadURI) return file.GCSUploadURI;
 
-    const { query, pathname } = url.parse(req.originalUrl || (req.url as string), true);
-    query.upload_id = file.id;
-    const relative = url.format({ pathname, query });
+    const requestUrl = new URL(req.originalUrl || req.url || '', 'http://localhost');
+    requestUrl.searchParams.set('upload_id', file.id);
+    const relative = requestUrl.pathname + requestUrl.search;
     if (this.storage.config.useRelativeLocation) return relative;
     const { baseUrl } = this.storage.config;
     const base = typeof baseUrl === 'function' ? baseUrl(req) : baseUrl || getBaseUrl(req);
@@ -119,8 +118,8 @@ export class Uploadx<TFile extends UploadxFile> extends BaseHandler<TFile> {
       fail(ERRORS.BAD_REQUEST, err)
     );
     if (Object.keys(metadata).length) return metadata;
-    const { query } = url.parse(decodeURI(req.url || ''), true);
-    return { ...query };
+    const { searchParams } = new URL(req.url || '', 'http://localhost');
+    return Object.fromEntries(searchParams);
   }
 
   extractChecksum(req: IncomingMessage): Checksum {

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -343,7 +343,6 @@ export abstract class BaseStorage<TFile extends File> {
     this.purgeTimeoutId = setTimeout(runPurge, interval).unref();
   }
 
-
   protected stopAutoPurge(): void {
     if (this.purgeTimeoutId) {
       clearTimeout(this.purgeTimeoutId);


### PR DESCRIPTION

 Replaces all usages of the deprecated `url.parse()` / `url.format()` from the `url` module with the native `URL` constructor. 