### PR TITLE
рefactor(multipart): improve error handling and metadata parsing

### DIFF
--- a/packages/core/src/handlers/multipart.ts
+++ b/packages/core/src/handlers/multipart.ts
@@ -12,10 +12,36 @@ interface MultipartyPart extends multiparty.Part {
 }
 
 export class Multipart<TFile extends UploadxFile> extends BaseHandler<TFile> {
+  /** @experimental */
+  errorMode: 'drain' | 'abort' =
+    process.env['MULTIPART_ERROR_MODE'] === 'abort' ? 'abort' : 'drain';
+
   async post(req: IncomingMessage, res: ServerResponse): Promise<TFile> {
     return new Promise((resolve, reject) => {
       const form = new multiparty.Form();
       const config: FileInit = { metadata: {} };
+      let rejected = false;
+
+      const onError = (error: Error): void => {
+        if (rejected) return;
+        rejected = true;
+        if (this.errorMode === 'drain' && req.readable && !req.destroyed) {
+          form.removeAllListeners();
+          req.unpipe();
+
+          req.on('readable', () => {
+            while (req.read() !== null) {
+              /* drain */
+            }
+          });
+
+          req.once('close', () => reject(error));
+          req.once('end', () => reject(error));
+        } else {
+          reject(error);
+        }
+      };
+
       form.on('field', (key, value) => {
         try {
           Object.assign(config.metadata, key === 'metadata' ? JSON.parse(value) : { [key]: value });
@@ -23,7 +49,7 @@ export class Multipart<TFile extends UploadxFile> extends BaseHandler<TFile> {
           config.metadata.raw = value;
         }
       });
-      form.on('error', error => reject(error));
+      form.on('error', error => onError(error));
       form.on('part', (part: MultipartyPart) => {
         config.size = part.byteCount;
         config.originalName = part.filename;
@@ -36,13 +62,17 @@ export class Multipart<TFile extends UploadxFile> extends BaseHandler<TFile> {
             this.storage.write({ start: 0, contentLength: part.byteCount, body: part, id })
           )
           .then(file => {
+            if (rejected) return;
             if (file.status === 'completed') {
               const headers = { Location: this.buildFileUrl(req, file) };
               setHeaders(res, headers);
             }
             return resolve(file);
           })
-          .catch(err => reject(err));
+          .catch((error: Error) => {
+            part.destroy();
+            onError(error);
+          });
       });
 
       form.parse(req);

--- a/packages/core/src/handlers/multipart.ts
+++ b/packages/core/src/handlers/multipart.ts
@@ -17,7 +17,11 @@ export class Multipart<TFile extends UploadxFile> extends BaseHandler<TFile> {
       const form = new multiparty.Form();
       const config: FileInit = { metadata: {} };
       form.on('field', (key, value) => {
-        Object.assign(config.metadata, key === 'metadata' ? JSON.parse(value) : { [key]: value });
+        try {
+          Object.assign(config.metadata, key === 'metadata' ? JSON.parse(value) : { [key]: value });
+        } catch {
+          config.metadata.raw = value;
+        }
       });
       form.on('error', error => reject(error));
       form.on('part', (part: MultipartyPart) => {

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -68,6 +68,16 @@ describe('::Multipart', () => {
         .expect(403)
         .catch(() => null); // FIXME: abort doesn't work?
     });
+
+    it('should save unparsable metadata as raw', async () => {
+      res = await request(app)
+        .post(basePath)
+        .set('Content-Type', 'multipart/formdata')
+        .field('metadata', 'not-valid-json')
+        .attach('file', testfile.asBuffer, testfile.name)
+        .expect(200);
+      expect(res.body.metadata.raw).toBe('not-valid-json');
+    });
   });
 
   describe('OPTIONS', () => {

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -60,13 +60,14 @@ describe('::Multipart', () => {
       expect(res.header['location']).toBeDefined();
     });
 
-    it('should 403 (unsupported filetype)', async () => {
+    it('should 415 (unsupported media type)', async () => {
       await request(app)
         .post(basePath)
-        .set('Content-Type', 'multipart/formdata')
-        .attach('file', 'package.json', 'package.json')
-        .expect(403)
-        .catch(() => null); // FIXME: abort doesn't work?
+        .attach('file', testfile.asBuffer, {
+          filename: 'test.json',
+          contentType: 'application/json'
+        })
+        .expect(415);
     });
 
     it('should save unparsable metadata as raw', async () => {


### PR DESCRIPTION
- `@experimental` error modes: `drain` (drains body before error response) and `abort` (rejects immediately)
- Graceful handling of unparsable metadata (stored as `metadata.raw`)