### PR TITLE
refactor: unify error variable naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,10 @@
     "examples"
   ],
   "lint-staged": {
-    "{packages,examples,test}/**/*.ts": "oxlint --fix && oxfmt",
+    "{packages,examples,test}/**/*.ts": [
+      "oxlint --fix",
+      "oxfmt"
+    ],
     "*.{md,json}": "oxfmt"
   }
 }

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -151,7 +151,7 @@ export abstract class BaseHandler<TFile extends UploadxFile>
         }
         return;
       })
-      .catch((error: Error) => {
+      .catch(error => {
         const errorPayload = {
           ...pick(error, Object.getOwnPropertyNames(error) as (keyof Error)[]),
           request: pick(req, ['headers', 'method', 'url'])

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -112,7 +112,7 @@ export abstract class BaseHandler<TFile extends UploadxFile>
       res.writeHead(204, { 'Content-Length': 0 }).end();
       return;
     }
-    req.on('error', error => this.logger.error('Request error', { error }));
+    req.on('error', err => this.logger.error('Request error', { err }));
     this.logger.debug('Request {method} {url}', { method: req.method, url: req.url });
     const handler = this.registeredHandlers.get(req.method as string);
     if (!handler) {
@@ -151,15 +151,15 @@ export abstract class BaseHandler<TFile extends UploadxFile>
         }
         return;
       })
-      .catch(error => {
+      .catch(err => {
         const errorPayload = {
-          ...pick(error, Object.getOwnPropertyNames(error) as (keyof Error)[]),
+          ...pick(err, Object.getOwnPropertyNames(err) as (keyof Error)[]),
           request: pick(req, ['headers', 'method', 'url'])
         };
         this.listenerCount('error') && this.emit('error', errorPayload as UploadxErrorEvent);
         this.logger.error('{errorPayload.message} {*}', { errorPayload });
         if ('aborted' in req && req['aborted']) return;
-        return this.sendError(res, error);
+        return this.sendError(res, err);
       });
   };
 

--- a/packages/core/src/handlers/multipart.ts
+++ b/packages/core/src/handlers/multipart.ts
@@ -49,7 +49,7 @@ export class Multipart<TFile extends UploadxFile> extends BaseHandler<TFile> {
           config.metadata.raw = value;
         }
       });
-      form.on('error', error => onError(error));
+      form.on('error', err => onError(err));
       form.on('part', (part: MultipartyPart) => {
         config.size = part.byteCount;
         config.originalName = part.filename;
@@ -69,9 +69,9 @@ export class Multipart<TFile extends UploadxFile> extends BaseHandler<TFile> {
             }
             return resolve(file);
           })
-          .catch(error => {
+          .catch(err => {
             part.destroy();
-            onError(error);
+            onError(err);
           });
       });
 

--- a/packages/core/src/handlers/multipart.ts
+++ b/packages/core/src/handlers/multipart.ts
@@ -22,7 +22,7 @@ export class Multipart<TFile extends UploadxFile> extends BaseHandler<TFile> {
       const config: FileInit = { metadata: {} };
       let rejected = false;
 
-      const onError = (error: Error): void => {
+      const onError = (error: unknown): void => {
         if (rejected) return;
         rejected = true;
         if (this.errorMode === 'drain' && req.readable && !req.destroyed) {
@@ -69,7 +69,7 @@ export class Multipart<TFile extends UploadxFile> extends BaseHandler<TFile> {
             }
             return resolve(file);
           })
-          .catch((error: Error) => {
+          .catch(error => {
             part.destroy();
             onError(error);
           });

--- a/packages/core/src/handlers/uploadx.ts
+++ b/packages/core/src/handlers/uploadx.ts
@@ -87,7 +87,7 @@ export class Uploadx<TFile extends UploadxFile> extends BaseHandler<TFile> {
 
   getId(req: IncomingMessage): string {
     const params = new URL(req.url || '', 'http://localhost').searchParams;
-    return (params.get('upload_id') || params.get('prefix') || super.getId(req));
+    return params.get('upload_id') || params.get('prefix') || super.getId(req);
   }
 
   buildHeaders(file: UploadxFile, headers: Headers = {}): Headers {

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -79,7 +79,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     this.isReady = false;
     this.accessCheck()
       .then(() => (this.isReady = true))
-      .catch((error: unknown) => {
+      .catch(error => {
         this.logger.error('Storage access check failed {error.message}', { error });
       });
   }
@@ -172,7 +172,7 @@ export class DiskStorage extends BaseStorage<DiskFile> {
         .pipe(lengthChecker)
         .pipe(checksumChecker)
         .pipe(dest)
-        .on('error', (err?: unknown): void => {
+        .on('error', err => {
           cleanupStreams();
           reject(err);
         })

--- a/packages/core/src/storages/disk-storage.ts
+++ b/packages/core/src/storages/disk-storage.ts
@@ -79,13 +79,13 @@ export class DiskStorage extends BaseStorage<DiskFile> {
     this.isReady = false;
     this.accessCheck()
       .then(() => (this.isReady = true))
-      .catch(error => {
-        this.logger.error('Storage access check failed {error.message}', { error });
+      .catch(err => {
+        this.logger.error('Storage access check failed {err.message}', { err });
       });
   }
 
-  normalizeError(err: Error): UploadxErrorResponse {
-    return super.normalizeError(err);
+  normalizeError(error: Error): UploadxErrorResponse {
+    return super.normalizeError(error);
   }
 
   accessCheck(): Promise<void> {

--- a/packages/core/src/storages/redis-meta-storage.ts
+++ b/packages/core/src/storages/redis-meta-storage.ts
@@ -40,8 +40,8 @@ export class RedisMetaStorage<T extends File = File> extends MetaStorage<T> {
       throw new Error('ioredis is not installed. Install it with: npm install ioredis');
     }
     this.client = new RedisCtor(redisOptions);
-    this.client.on('error', error => {
-      this.logger.error('Redis connection error', { error });
+    this.client.on('error', err => {
+      this.logger.error('Redis connection error', { err });
     });
   }
 

--- a/packages/core/src/storages/redis-meta-storage.ts
+++ b/packages/core/src/storages/redis-meta-storage.ts
@@ -40,7 +40,7 @@ export class RedisMetaStorage<T extends File = File> extends MetaStorage<T> {
       throw new Error('ioredis is not installed. Install it with: npm install ioredis');
     }
     this.client = new RedisCtor(redisOptions);
-    this.client.on('error', (error: Error) => {
+    this.client.on('error', error => {
       this.logger.error('Redis connection error', { error });
     });
   }

--- a/packages/core/src/storages/storage.ts
+++ b/packages/core/src/storages/storage.ts
@@ -333,7 +333,7 @@ export abstract class BaseStorage<TFile extends File> {
     }
     const runPurge = (): void => {
       this.purge()
-        .catch(e => this.logger.error('purge error: {e}', { e }))
+        .catch(err => this.logger.error('purge error: {err}', { err }))
         .finally(() => {
           if (this.purgeTimeoutId) {
             this.purgeTimeoutId = setTimeout(runPurge, interval).unref();

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -90,8 +90,8 @@ export class UploadxError extends Error {
   }
 }
 
-export function isUploadxError(err: unknown): err is UploadxError {
-  return !!(err as UploadxError)?.uploadxErrorCode;
+export function isUploadxError(error: unknown): error is UploadxError {
+  return !!(error as UploadxError)?.uploadxErrorCode;
 }
 
 export function normalizeErrorResponse(

--- a/packages/gcs/src/gcs-storage.ts
+++ b/packages/gcs/src/gcs-storage.ts
@@ -122,7 +122,7 @@ export class GCStorage extends BaseStorage<GCSFile> {
     this.isReady = false;
     this.accessCheck()
       .then(() => (this.isReady = true))
-      .catch(error => this.logger.error('Storage access check failed: {error.message}', { error }));
+      .catch(err => this.logger.error('Storage access check failed: {err.message}', { err }));
   }
 
   normalizeError(error: ClientError): UploadxErrorResponse {
@@ -233,8 +233,8 @@ export class GCStorage extends BaseStorage<GCSFile> {
         config: { uri },
         name: 'FetchError'
       });
-    } catch (error) {
-      this.logger.error('Upload chunk failed', { uri, error });
+    } catch (err) {
+      this.logger.error('Upload chunk failed', { uri, err });
       return NaN;
     }
   }

--- a/packages/s3/src/s3-storage.ts
+++ b/packages/s3/src/s3-storage.ts
@@ -150,7 +150,7 @@ export class S3Storage extends BaseStorage<S3File> {
     this.isReady = false;
     this.accessCheck()
       .then(() => (this.isReady = true))
-      .catch(error => this.logger.error('Storage access check failed: {error.message}', { error }));
+      .catch(err => this.logger.error('Storage access check failed: {err.message}', { err }));
   }
 
   normalizeError(error: AWSError): UploadxErrorResponse {
@@ -348,8 +348,8 @@ export class S3Storage extends BaseStorage<S3File> {
     try {
       const params = { Bucket: this.bucket, Key: file.name, UploadId: file.UploadId };
       await this.client.send(new AbortMultipartUploadCommand(params));
-    } catch (error) {
-      this.logger.error('Abort multipart upload failed', { error });
+    } catch (err) {
+      this.logger.error('Abort multipart upload failed', { err });
     }
   }
 }

--- a/test/cors.spec.ts
+++ b/test/cors.spec.ts
@@ -86,14 +86,11 @@ describe('CORS', () => {
       [['http://example.com'], 'https://example.com', undefined],
       [['https://*.example.com'], 'https://evil.com.example.com.evil', undefined],
       [['https://*.example.com'], 'https://sub.example.com', 'https://sub.example.com']
-    ])(
-      'allowOrigins %p origin %s => %s',
-      (allowOrigins, testOrigin, expected) => {
-        cors.allowOrigins = allowOrigins;
-        req.headers.origin = testOrigin;
-        cors.preflight(req, res);
-        expect(res.header('Access-Control-Allow-Origin')).toBe(expected);
-      }
-    );
+    ])('allowOrigins %p origin %s => %s', (allowOrigins, testOrigin, expected) => {
+      cors.allowOrigins = allowOrigins;
+      req.headers.origin = testOrigin;
+      cors.preflight(req, res);
+      expect(res.header('Access-Control-Allow-Origin')).toBe(expected);
+    });
   });
 });


### PR DESCRIPTION
- Renamed error variables to follow consistent convention:
  `err` for callbacks/catch blocks, `error` for function parameters
- Fixed formatting issues
- Removed redundant type annotations
- Fixed lint-staged config to correctly pass files to oxfmt