### PR TITLE
fix(core): improve filename validation

### DIFF
--- a/packages/core/src/storages/file.ts
+++ b/packages/core/src/storages/file.ts
@@ -113,11 +113,11 @@ export function getFileStatus(file: File): UploadxEventType {
 }
 
 export class FileName {
-  static INVALID_CHARS = ['"', '*', ':', '<', '>', '?', '\\', '|', '../'];
+  static INVALID_CHARS = ['"', '*', ':', '<', '>', '?', '\\', '|'];
   static INVALID_PREFIXES: string[] = [];
   static INVALID_SUFFIXES: string[] = [];
   static MAX_LENGTH = 255;
-  static MIN_LENGTH = 3;
+  static MIN_LENGTH = 1;
   static isValid(name: string): boolean {
     if (
       !name ||
@@ -126,14 +126,17 @@ export class FileName {
       isAbsolute(name)
     ) {
       return false;
-    } else {
-      const upperCase = name.toUpperCase();
-      return !(
-        FileName.INVALID_CHARS.filter(Boolean).some(chars => upperCase.includes(chars)) ||
-        FileName.INVALID_PREFIXES.filter(Boolean).some(chars => upperCase.startsWith(chars)) ||
-        FileName.INVALID_SUFFIXES.filter(Boolean).some(chars => upperCase.endsWith(chars))
-      );
     }
+    if (name.split('/').some(part => part === '.' || part === '..')) return false;
+    for (let i = 0; i < name.length; i++) {
+      if (name.charCodeAt(i) < 32 || name.charCodeAt(i) === 127) return false;
+    }
+    const upperCase = name.toUpperCase();
+    return !(
+      FileName.INVALID_CHARS.filter(Boolean).some(chars => upperCase.includes(chars)) ||
+      FileName.INVALID_PREFIXES.filter(Boolean).some(chars => upperCase.startsWith(chars)) ||
+      FileName.INVALID_SUFFIXES.filter(Boolean).some(chars => upperCase.endsWith(chars))
+    );
   }
 }
 

--- a/test/file.spec.ts
+++ b/test/file.spec.ts
@@ -4,15 +4,31 @@ describe('File', () => {
   describe('FileName', () => {
     it.each([
       ['', false],
+      ['.', false],
       ['..', false],
       ['c:\\abs', false],
-      ['12', false],
+      ['1', true],
       ['filename?.ext', false],
       ['../filename.ext', false],
       ['/filename.ext', false],
-      ['filename.ext', true]
+      ['filename.ext', true],
+      ['.filename', true],
+      ['file..ext', true],
+      ['foo/bar', true]
     ])('isValid(%s) === %s', (str, expected) => {
       expect(FileName.isValid(str)).toBe(expected);
+    });
+
+    it.each([
+      ['null byte', '\0'],
+      ['newline', '\n'],
+      ['tab', '\t'],
+      ['carriage return', '\r'],
+      ['DEL', '\x7F'],
+      ['safe\\n.txt', 'safe\n.txt'],
+      ['safe\\x7F.txt', 'safe\x7F.txt']
+    ])('rejects %s', (_, input) => {
+      expect(FileName.isValid(input)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
- Lower filename `MIN_LENGTH` to 1, reject control characters in filenames