### PR TITLE
fix(core): handle empty suffix in getIdFromMetaName

### DIFF
--- a/packages/core/src/storages/local-meta-storage.ts
+++ b/packages/core/src/storages/local-meta-storage.ts
@@ -29,14 +29,9 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
    * Returns metafile path
    * @param id - upload id
    */
-  getMetaPath = (id: string): string => `${this.directory}/${this.prefix + id + this.suffix}`;
-
-  /**
-   * Returns upload id from metafile path
-   * @internal
-   */
-  getIdFromPath = (metaFilePath: string): string =>
-    metaFilePath.slice(`${this.directory}/${this.prefix}`.length, -this.suffix.length);
+  getMetaPath(id: string): string {
+    return `${this.directory}/${this.prefix + id + this.suffix}`;
+  }
 
   async save(id: string, file: T): Promise<T> {
     await fsp.writeFile(this.getMetaPath(id), JSON.stringify(file, null, 2));
@@ -74,6 +69,10 @@ export class LocalMetaStorage<T extends File = File> extends MetaStorage<T> {
 
   toString(): string {
     return `[${this.constructor.name}: directory="${this.directory}", prefix="${this.prefix}", suffix="${this.suffix}"]`;
+  }
+
+  private getIdFromPath(metaFilePath: string): string {
+    return this.getIdFromMetaName(metaFilePath.slice(`${this.directory}/`.length));
   }
 
   private accessCheck(): Promise<void> {

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -18,7 +18,17 @@ export interface UploadList {
 }
 
 export interface MetaStorageOptions {
+  /**
+   * Prefix added to the storage key (file path, Redis key, etc.).
+   * @default ''
+   */
   prefix?: string;
+
+  /**
+   * Suffix appended to the storage key.
+   * Prevents name collisions when storing metadata alongside binary files.
+   * @default '.META'
+   */
   suffix?: string;
 }
 
@@ -28,6 +38,7 @@ export interface MetaStorageOptions {
 export class MetaStorage<T> {
   prefix = '';
   suffix = '';
+
   logger: Logger = uploadxLogger.getChild(this.constructor.name);
 
   constructor(options?: MetaStorageOptions) {

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -32,7 +32,7 @@ export class MetaStorage<T> {
 
   constructor(options?: MetaStorageOptions) {
     this.prefix = options?.prefix ?? '';
-    this.suffix = options?.suffix ?? METAFILE_EXTNAME;
+    this.suffix = options?.suffix ?? '.META';
     this.prefix && FileName.INVALID_PREFIXES.push(this.prefix);
     this.suffix && FileName.INVALID_SUFFIXES.push(this.suffix);
   }
@@ -89,8 +89,3 @@ export class MetaStorage<T> {
     return this.toString();
   }
 }
-
-/**
- * @deprecated Use MetaStorage.suffix instead
- */
-export const METAFILE_EXTNAME = '.META';

--- a/packages/core/src/storages/meta-storage.ts
+++ b/packages/core/src/storages/meta-storage.ts
@@ -78,7 +78,7 @@ export class MetaStorage<T> {
   }
 
   getIdFromMetaName(name: string): string {
-    return name.slice(this.prefix.length, -this.suffix.length);
+    return name.slice(this.prefix.length, name.length - this.suffix.length);
   }
 
   toString(): string {

--- a/test/local-meta-storage.spec.ts
+++ b/test/local-meta-storage.spec.ts
@@ -1,38 +1,42 @@
 import { LocalMetaStorage } from '../packages/core/src';
-import * as path from 'path';
 import { metafile } from './shared';
-import { tmpdir } from 'os';
 
 jest.mock('fs/promises');
 jest.mock('fs');
 
 describe('LocalMetaStorage', () => {
-  it('defaults', () => {
-    const meta = new LocalMetaStorage();
-    const metaPath = meta.getMetaPath(metafile.id);
-    expect(path.basename(metaPath)).toBe(`${metafile.id}.META`);
-    expect(meta.getIdFromPath(metaPath)).toBe(metafile.id);
-  });
-
-  it('custom', () => {
-    const meta = new LocalMetaStorage({
-      prefix: '.',
-      suffix: '.',
-      directory: path.join(tmpdir(), 'meta')
+  describe('list', () => {
+    it('default', async () => {
+      const meta = new LocalMetaStorage({ directory: '/m1' });
+      await meta.save(metafile.id, metafile);
+      const list = await meta.list();
+      expect(list.items).toHaveLength(1);
+      expect(list.items[0]).toMatchObject({ id: metafile.id });
     });
-    const metaPath = meta.getMetaPath(metafile.id);
-    expect(path.basename(metaPath)).toBe(`.${metafile.id}.`);
-    expect(meta.getIdFromPath(metaPath)).toBe(metafile.id);
-  });
 
-  it('methods', async () => {
-    const meta = new LocalMetaStorage();
-    await meta.save(metafile.id, metafile);
-    await expect(meta.get(metafile.id)).resolves.toEqual(metafile);
-    const list = await meta.list(metafile.id.slice(0, 8));
-    expect(list.items[0]).toMatchObject({ id: metafile.id });
-    await expect(meta.list('alien')).resolves.toEqual({ items: [] });
-    await meta.delete(metafile.id);
-    await expect(meta.list()).resolves.toEqual({ items: [] });
+    it('custom', async () => {
+      const meta = new LocalMetaStorage({ prefix: '.', suffix: '.', directory: '/m2' });
+      await meta.save(metafile.id, metafile);
+      const list = await meta.list();
+      expect(list.items).toHaveLength(1);
+      expect(list.items[0]).toMatchObject({ id: metafile.id });
+    });
+
+    it('empty suffix', async () => {
+      const meta = new LocalMetaStorage({ suffix: '', directory: '/m3' });
+      await meta.save(metafile.id, metafile);
+      const list = await meta.list();
+      expect(list.items).toHaveLength(1);
+      expect(list.items[0].id).toBe(metafile.id);
+    });
+
+    it('with idPrefix', async () => {
+      const meta = new LocalMetaStorage({ directory: '/m4' });
+      const idPrefix = metafile.id.slice(0, 8);
+      await meta.save(metafile.id, metafile);
+      const list = await meta.list(idPrefix);
+      expect(list.items[0]).toMatchObject({ id: metafile.id });
+      await expect(meta.list('alien')).resolves.toEqual({ items: [] });
+    });
   });
 });

--- a/test/meta-storage.spec.ts
+++ b/test/meta-storage.spec.ts
@@ -24,4 +24,41 @@ describe('MetaStorage', () => {
   it('list', async () => {
     await expect(metaStorage.list()).resolves.toEqual({ items: [] });
   });
+
+  describe('getIdFromMetaName', () => {
+    it('default suffix', () => {
+      const meta = new MetaStorage();
+      const name = meta.getMetaName(metafile.id);
+      expect(name).toBe(`${metafile.id}.META`);
+      expect(meta.getIdFromMetaName(name)).toBe(metafile.id);
+    });
+
+    it('custom prefix', () => {
+      const meta = new MetaStorage({ prefix: 'archive/' });
+      const name = meta.getMetaName(metafile.id);
+      expect(name).toBe(`archive/${metafile.id}.META`);
+      expect(meta.getIdFromMetaName(name)).toBe(metafile.id);
+    });
+
+    it('custom suffix', () => {
+      const meta = new MetaStorage({ suffix: '.json' });
+      const name = meta.getMetaName(metafile.id);
+      expect(name).toBe(`${metafile.id}.json`);
+      expect(meta.getIdFromMetaName(name)).toBe(metafile.id);
+    });
+
+    it('custom both', () => {
+      const meta = new MetaStorage({ prefix: 'logs/', suffix: '.meta' });
+      const name = meta.getMetaName(metafile.id);
+      expect(name).toBe(`logs/${metafile.id}.meta`);
+      expect(meta.getIdFromMetaName(name)).toBe(metafile.id);
+    });
+
+    it('empty suffix', () => {
+      const meta = new MetaStorage({ suffix: '' });
+      const name = meta.getMetaName(metafile.id);
+      expect(name).toBe(metafile.id);
+      expect(meta.getIdFromMetaName(name)).toBe(metafile.id);
+    });
+  });
 });

--- a/test/shared/config.ts
+++ b/test/shared/config.ts
@@ -1,5 +1,4 @@
 import type { BaseStorageOptions, File } from '../../packages/core/src';
-import { METAFILE_EXTNAME } from '../../packages/core/src';
 import * as path from 'path';
 import { tmpdir } from 'os';
 import { Readable } from 'stream';
@@ -39,7 +38,7 @@ export const metadata = {
 export const testfile = {
   ...metadata,
   filename: metadata.name,
-  metafilename: id + METAFILE_EXTNAME,
+  metafilename: `${id}.META`,
   asBuffer: fileAsBuffer,
   asReadable: fileAsReadStream,
   contentType: metadata.mimeType


### PR DESCRIPTION
- Fix `getIdFromMetaName` returning empty string when `suffix` is an empty string.
- Delegate `LocalMetaStorage.getIdFromPath` to `getIdFromMetaName`.
- Remove deprecated `METAFILE_EXTNAME`