### PR TITLE
fix(core): validate basePath for raw Node.js requests

### DIFF
--- a/examples/node-http-server.js
+++ b/examples/node-http-server.js
@@ -1,9 +1,7 @@
 const { createServer } = require('http');
-const { DiskStorage, Uploadx, cors } = require('@uploadx/core');
+const { DiskStorage, Uploadx } = require('@uploadx/core');
 
 const PORT = process.env.PORT || 3002;
-
-const corsHandler = cors();
 
 const storage = new DiskStorage({
   uploadDir: process.env.UPLOAD_DIR || 'upload',
@@ -22,16 +20,7 @@ uploadx.on('completed', file => console.log('completed: ', file));
 uploadx.on('updated', file => console.log(' metadata updated: ', file));
 
 const server = createServer((req, res) => {
-  const { pathname } = new URL(req.url || '', 'http://localhost');
-  if (pathname === '/files') {
-    uploadx.upload(req, res, () => {
-      uploadx.send(res, { body: req.body, statusCode: 200 });
-    });
-  } else {
-    corsHandler(req, res, () => {
-      uploadx.send(res, { body: 'Not Found', statusCode: 404 });
-    });
-  }
+  uploadx.handle(req, res);
 });
 
 server.listen(+PORT, () => console.log('listening on port:', PORT));

--- a/examples/server.js
+++ b/examples/server.js
@@ -3,11 +3,9 @@ const { cors, DiskStorage, Multipart, Tus, Uploadx, fromEnv } = require('@upload
 const { createServer } = require('http');
 
 const PORT = process.env.PORT || 3002;
-const path = '/files';
-const pathRegexp = new RegExp(`^${path}([/?]|$)`);
 
 const config = {
-  basePath: path,
+  basePath: '/files',
   uploadDir: './upload',
   allowedMimeTypes: ['video/*', 'image/*'],
   maxFileSize: '2GB',
@@ -15,7 +13,6 @@ const config = {
   ...fromEnv()
 };
 
-const corsHandler = cors();
 const storage = new DiskStorage(config);
 const uploadx = new Uploadx({ storage });
 const tus = new Tus({ storage });
@@ -30,8 +27,8 @@ createServer((req, res) => {
       message: 'status 👍',
       timestamp: Date.now()
     };
-    corsHandler(req, res, () => uploadx.send(res, { body: healthcheck }));
-  } else if (pathname && pathRegexp.test(pathname)) {
+    cors()(req, res, () => uploadx.send(res, { body: healthcheck }));
+  } else {
     switch (searchParams.get('uploadType')) {
       case 'multipart':
         multipart.handle(req, res);
@@ -43,7 +40,5 @@ createServer((req, res) => {
         uploadx.handle(req, res);
         break;
     }
-  } else {
-    corsHandler(req, res, () => uploadx.send(res, { body: 'Not Found', statusCode: 404 }));
   }
 }).listen(PORT);

--- a/packages/core/src/handlers/base-handler.ts
+++ b/packages/core/src/handlers/base-handler.ts
@@ -112,6 +112,13 @@ export abstract class BaseHandler<TFile extends UploadxFile>
       res.writeHead(204, { 'Content-Length': 0 }).end();
       return;
     }
+    if (!req.originalUrl) {
+      const { pathname } = new URL(req.url || '', 'http://localhost');
+      const basePath = this.storage.basePath;
+      const match =
+        basePath === '/' || pathname === basePath || pathname.startsWith(`${basePath}/`);
+      if (!match) return this.sendError(res, new UploadxError(ERRORS.FILE_NOT_FOUND));
+    }
     req.on('error', err => this.logger.error('Request error', { err }));
     this.logger.debug('Request {method} {url}', { method: req.method, url: req.url });
     const handler = this.registeredHandlers.get(req.method as string);

--- a/test/base-handler.spec.ts
+++ b/test/base-handler.spec.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import { createRequest, createResponse } from 'node-mocks-http';
-import { testStorage, TestUploader } from './shared';
+import { testStorage, TestStorage, TestUploader } from './shared';
 
 describe('BaseHandler', () => {
   let uploader: TestUploader;
@@ -90,6 +90,38 @@ describe('BaseHandler', () => {
     ['/3/files/4', '']
   ])('nodejs: getId(%p) === %p', (url, id) => {
     expect(uploader.getId({ url } as http.IncomingMessage)).toBe(id);
+  });
+
+  it('should reject path outside basePath (raw Node.js)', () => {
+    const res = createResponse();
+    const req = createRequest({ method: 'GET', url: '/wrong' });
+    delete (req as any).originalUrl;
+    uploader.handle(req, res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should accept path matching basePath (raw Node.js)', () => {
+    const res = createResponse();
+    const req = createRequest({ method: 'PATCH', url: '/files' });
+    delete (req as any).originalUrl;
+    uploader.handle(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('should accept all paths when basePath is "/"', () => {
+    const uploader2 = new TestUploader({ storage: new TestStorage({ basePath: '/' }) });
+    const res = createResponse();
+    const req = createRequest({ method: 'PATCH', url: '/anything' });
+    delete (req as any).originalUrl;
+    uploader2.handle(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('should skip basePath check when originalUrl is set', () => {
+    const res = createResponse();
+    const req = createRequest({ method: 'PATCH', url: '/api/other' });
+    uploader.handle(req, res);
+    expect(res.statusCode).toBe(405);
   });
 
   interface MockReq extends http.IncomingMessage {

--- a/test/base-handler.spec.ts
+++ b/test/base-handler.spec.ts
@@ -18,13 +18,13 @@ describe('BaseHandler', () => {
   it('should check if storage not ready', () => {
     uploader.storage.isReady = false;
     const res = createResponse();
-    uploader.handle(createRequest({ method: 'OPTIONS' }), res);
+    uploader.handle(createRequest({ method: 'OPTIONS', url: '/files' }), res);
     expect(res.statusCode).toBe(503);
   });
 
   it('should check http method', () => {
     const res = createResponse();
-    uploader.handle(createRequest({ method: 'PATCH' }), res);
+    uploader.handle(createRequest({ method: 'PATCH', url: '/files' }), res);
     expect(res.statusCode).toBe(405);
   });
 


### PR DESCRIPTION
- Add `basePath` validation to `BaseHandler`.
- Simplify examples to use the new built-in check instead of manual path routing.