### PR TITLE
fix(core): keep port in getBaseUrl for Express 4

### DIFF
--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -111,7 +111,12 @@ export function getBaseUrl(req: http.IncomingMessage): string {
  * Extracts host with port from a http or https request.
  */
 function extractHost(req: http.IncomingMessage & { host?: string }): string {
-  return req.host || getHeader(req, 'host');
+  const headerHost = getHeader(req, 'host');
+  const host = req.host;
+  if (!host) return headerHost;
+  // Express 4 strips the port from req.host; restore it
+  // only when the Host header points to the same hostname
+  return headerHost.toLowerCase().startsWith(`${host.toLowerCase()}:`) ? headerHost : host;
 }
 
 /**

--- a/test/http-utils.spec.ts
+++ b/test/http-utils.spec.ts
@@ -1,65 +1,94 @@
-import { IncomingMessage } from 'http';
+import { IncomingHttpHeaders, IncomingMessage } from 'http';
 import * as utils from '../packages/core/src';
+
+type TestRequest = IncomingMessage & { host?: string };
+
+function buildReq(headers: IncomingHttpHeaders = {}, host?: string): TestRequest {
+  const req = { headers } as TestRequest;
+  if (host !== undefined) req.host = host;
+  return req;
+}
 
 describe('http utils', () => {
   const mime = 'application/vnd+json';
-  const req = { headers: { 'content-type': mime } } as IncomingMessage;
+  const req = buildReq({ 'content-type': mime });
 
-  it('typeis()', () => {
-    expect(utils.typeis({ headers: {} } as IncomingMessage, ['json'])).toBe(false);
-    expect(utils.typeis(req, ['html'])).toBe(false);
-    expect(utils.typeis(req, ['json'])).toBe(mime);
+  describe('typeis', () => {
+    it('detects request content type', () => {
+      expect(utils.typeis(buildReq(), ['json'])).toBe(false);
+      expect(utils.typeis(req, ['html'])).toBe(false);
+      expect(utils.typeis(req, ['json'])).toBe(mime);
+    });
+
+    it('matches mime patterns', () => {
+      expect(utils.typeis.is(mime, ['application/vnd+json'])).toBe(mime);
+      expect(utils.typeis.is(mime, ['vnd+json'])).toBe(mime);
+      expect(utils.typeis.is(mime, ['application/*'])).toBe(mime);
+      expect(utils.typeis.is(mime, ['json', 'xml'])).toBe(mime);
+      expect(utils.typeis.is(mime, ['*/*'])).toBe(mime);
+    });
+
+    it('detects body from content length', () => {
+      expect(utils.typeis.hasBody(buildReq())).toBe(false);
+      expect(utils.typeis.hasBody(buildReq({ 'content-length': '0' }))).toBe(0);
+      expect(utils.typeis.hasBody(buildReq({ 'content-length': '1' }))).toBe(1);
+    });
   });
 
-  it('typeis.is()', () => {
-    expect(utils.typeis.is(mime, ['application/vnd+json'])).toBe(mime);
-    expect(utils.typeis.is(mime, ['vnd+json'])).toBe(mime);
-    expect(utils.typeis.is(mime, ['application/*'])).toBe(mime);
-    expect(utils.typeis.is(mime, ['json', 'xml'])).toBe(mime);
-    expect(utils.typeis.is(mime, ['*/*'])).toBe(mime);
+  describe('getHeader', () => {
+    it('not exist', () => {
+      expect(utils.getHeader(req, 'not exist')).toBe('');
+    });
+
+    it('single', () => {
+      const r = buildReq({ head: 'value' });
+      expect(utils.getHeader(r, 'head')).toBe('value');
+    });
+
+    it('array', () => {
+      const r = buildReq({ head: ['value1', 'value2 '] });
+      expect(utils.getHeader(r, 'head')).toBe('value2');
+    });
+
+    it('multiple', () => {
+      const r = buildReq({ head: 'value1 ,value2' });
+      expect(utils.getHeader(r, 'head')).toBe('value2');
+    });
+
+    it('multiple, all', () => {
+      const r = buildReq({ head: 'value1,value2 ' });
+      expect(utils.getHeader(r, 'head', true)).toBe('value1,value2');
+    });
   });
 
-  it('typeis.hasBody()', () => {
-    expect(utils.typeis.hasBody({ headers: {} } as IncomingMessage)).toBe(false);
-    expect(utils.typeis.hasBody({ headers: { 'content-length': '0' } } as IncomingMessage)).toBe(0);
-    expect(utils.typeis.hasBody({ headers: { 'content-length': '1' } } as IncomingMessage)).toBe(1);
-  });
+  describe('getBaseUrl', () => {
+    it('no-host', () => {
+      expect(utils.getBaseUrl(req)).toBe('');
+    });
 
-  it('getHeader(not exist)', () => {
-    expect(utils.getHeader(req, 'not exist')).toBe('');
-  });
+    it('no-proto', () => {
+      const r = buildReq({ host: 'example' });
+      expect(utils.getBaseUrl(r)).toBe('//example');
+    });
 
-  it('getHeader(single)', () => {
-    req.headers = { head: 'value' };
-    expect(utils.getHeader(req, 'head')).toBe('value');
-  });
+    it('absolute', () => {
+      const r = buildReq({ host: 'example:4443', 'x-forwarded-proto': 'https' });
+      expect(utils.getBaseUrl(r)).toBe('https://example:4443');
+    });
 
-  it('getHeader(array)', () => {
-    req.headers = { head: ['value1', 'value2 '] };
-    expect(utils.getHeader(req, 'head')).toBe('value2');
-  });
+    it('express4 host without port', () => {
+      const r = buildReq({ host: 'example:4443', 'x-forwarded-proto': 'https' }, 'example');
+      expect(utils.getBaseUrl(r)).toBe('https://example:4443');
+    });
 
-  it('getHeader(multiple)', () => {
-    req.headers = { head: 'value1 ,value2' };
-    expect(utils.getHeader(req, 'head')).toBe('value2');
-  });
+    it('forwarded host without port', () => {
+      const r = buildReq({ host: 'internal:3002', 'x-forwarded-proto': 'https' }, 'public.example');
+      expect(utils.getBaseUrl(r)).toBe('https://public.example');
+    });
 
-  it('getHeader(multiple, all)', () => {
-    req.headers = { head: 'value1,value2 ' };
-    expect(utils.getHeader(req, 'head', true)).toBe('value1,value2');
-  });
-
-  it('getBaseUrl(no-host)', () => {
-    expect(utils.getBaseUrl(req)).toBe('');
-  });
-
-  it('getBaseUrl(no-proto)', () => {
-    req.headers = { host: 'example' };
-    expect(utils.getBaseUrl(req)).toBe('//example');
-  });
-
-  it('getBaseUrl(absolute)', () => {
-    req.headers = { host: 'example:4443', 'x-forwarded-proto': 'https' };
-    expect(utils.getBaseUrl(req)).toBe('https://example:4443');
+    it('fallback to req.host when header is missing', () => {
+      const r = buildReq({}, 'example:4443');
+      expect(utils.getBaseUrl(r)).toBe('//example:4443');
+    });
   });
 });


### PR DESCRIPTION
Fixes `getBaseUrl()` dropping the port on Express 4 (`req.host` strips it) by restoring it from the `Host` header (alternatively, set `baseUrl` explicitly on non-default ports).