### PR TITLE
chore(core): widen ioredis range to allow v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7302,9 +7302,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/supertest": "^7.2.0",
         "express": "^5.2.1",
         "husky": "^9.1.7",
+        "ioredis": "^5.11.1",
         "ioredis-mock": "^8.13.1",
         "jest": "^30.4.2",
         "lint-staged": "^16.4.0",
@@ -10757,7 +10758,7 @@
         "node": ">=20.19.0"
       },
       "optionalDependencies": {
-        "ioredis": "^5.10.1"
+        "ioredis": "^5.10.1 || ^6.0.0"
       }
     },
     "packages/gcs": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/supertest": "^7.2.0",
     "express": "^5.2.1",
     "husky": "^9.1.7",
+    "ioredis": "^5.11.1",
     "ioredis-mock": "^8.13.1",
     "jest": "^30.4.2",
     "lint-staged": "^16.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "multiparty": "^4.3.0"
   },
   "optionalDependencies": {
-    "ioredis": "^5.10.1"
+    "ioredis": "^5.10.1 || ^6.0.0"
   },
   "devDependencies": {
     "@types/bytes": "3.1.1",


### PR DESCRIPTION
Widen the optional `ioredis` dependency of `@uploadx/core` to `^5.10.1 || ^6.0.0` and add `ioredis` to root to keep a single version in the dev tree. 

